### PR TITLE
Use Guzzle components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,13 @@
         }
     ],
     "require": {
-        "guzzle/guzzle": "~3.4",
+        "guzzle/http": "~3.4",
         "jms/serializer": "0.12.*",
         "psr/log": "~1.0",
         "symfony/console": "~2.3"
     },
     "require-dev": {
+        "guzzle/plugin-mock": "~3.4",
         "monolog/monolog": "~1.4"
     },
     "suggest": {


### PR DESCRIPTION
The SDK only uses a small portion of the Guzzle library, so this switches it to the one required component (+ one for dev).
