### PR TITLE
update guzzle to version 3.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "guzzle/http": "~3.4",
+        "guzzle/http": "~3.7",
         "jms/serializer": "0.12.*",
         "psr/log": "~1.0",
         "symfony/console": "~2.3",


### PR DESCRIPTION
You call `GuzzleClient::setDefaultOption` (https://github.com/sensiolabs/insight/blob/master/Sdk/Api.php#L54), which is implemented since guzzle 3.7
