### PR TITLE
Added the travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: php
+
+php:
+  - 5.3.3
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - hhvm
+
+before_script:
+  - composer install --prefer-source --no-interaction
+
+branches:
+  only:
+    - master


### PR DESCRIPTION
As Fabien enabled Travis on the repo, we need the config file to run a PHP build rather than a Ruby one
