### PR TITLE
Added phpdoc on all getters

### DIFF
--- a/Sdk/Api.php
+++ b/Sdk/Api.php
@@ -22,7 +22,10 @@ use JMS\Serializer\SerializerBuilder;
 use Psr\Log\LoggerInterface;
 use SensioLabs\Insight\Sdk\Exception\ApiClientException;
 use SensioLabs\Insight\Sdk\Exception\ApiServerException;
+use SensioLabs\Insight\Sdk\Model\Analyses;
+use SensioLabs\Insight\Sdk\Model\Analysis;
 use SensioLabs\Insight\Sdk\Model\Project;
+use SensioLabs\Insight\Sdk\Model\Projects;
 
 class Api
 {
@@ -67,6 +70,11 @@ class Api
         $this->logger = $logger;
     }
 
+    /**
+     * @param int $page
+     *
+     * @return Projects
+     */
     public function getProjects($page = 1)
     {
         $request = $this->client->createRequest('GET', '/api/projects');
@@ -81,6 +89,11 @@ class Api
         );
     }
 
+    /**
+     * @param string $uuid
+     *
+     * @return Project
+     */
     public function getProject($uuid)
     {
         $request = $this->client->createRequest('GET', sprintf('/api/projects/%s', $uuid));
@@ -92,6 +105,11 @@ class Api
         );
     }
 
+    /**
+     * @param Project $project
+     *
+     * @return Project
+     */
     public function updateProject(Project $project)
     {
         $request = $this->client->createRequest('PUT', sprintf('/api/projects/%s', $project->getUuid()), null, array('insight_project' => $project->toArray()));
@@ -103,6 +121,11 @@ class Api
         );
     }
 
+    /**
+     * @param Project $project
+     *
+     * @return Project
+     */
     public function createProject(Project $project)
     {
         $request = $this->client->createRequest('POST', '/api/projects', null, array('insight_project' => $project->toArray()));
@@ -114,6 +137,11 @@ class Api
         );
     }
 
+    /**
+     * @param string $projectUuid
+     *
+     * @return Analyses
+     */
     public function getAnalyses($projectUuid)
     {
         $request = $this->client->createRequest('GET', sprintf('/api/projects/%s/analyses', $projectUuid));
@@ -125,6 +153,12 @@ class Api
         );
     }
 
+    /**
+     * @param string $projectUuid
+     * @param int    $analysesNumber
+     *
+     * @return Analysis
+     */
     public function getAnalysis($projectUuid, $analysesNumber)
     {
         $request = $this->client->createRequest('GET', sprintf('/api/projects/%s/analyses/%s', $projectUuid, $analysesNumber));
@@ -136,6 +170,12 @@ class Api
         );
     }
 
+    /**
+     * @param string $projectUuid
+     * @param int    $analysesNumber
+     *
+     * @return Analysis an incomplete Analysis object
+     */
     public function getAnalysisStatus($projectUuid, $analysesNumber)
     {
         $request = $this->client->createRequest('GET', sprintf('/api/projects/%s/analyses/%s/status', $projectUuid, $analysesNumber));
@@ -147,6 +187,12 @@ class Api
         );
     }
 
+    /**
+     * @param string      $projectUuid
+     * @param string|null $reference   A git reference. It can be a commit sha, a tag name or a branch name
+     *
+     * @return Analysis
+     */
     public function analyze($projectUuid, $reference = null)
     {
         $request = $this->client->createRequest('POST', sprintf('/api/projects/%s/analyses', $projectUuid), array(), array('reference' => $reference));
@@ -183,6 +229,9 @@ class Api
         return $this;
     }
 
+    /**
+     * @return Serializer
+     */
     public function getSerializer()
     {
         return $this->serializer;

--- a/Sdk/Model/Analyses.php
+++ b/Sdk/Model/Analyses.php
@@ -20,19 +20,25 @@ class Analyses
      * @Type("array<SensioLabs\Insight\Sdk\Model\Link>")
      * @XmlList(inline = true, entry = "link")
      */
-    private $links;
+    private $links = array();
 
     /**
      * @Type("array<SensioLabs\Insight\Sdk\Model\Analysis>")
      * @XmlList(inline = true, entry = "analysis")
      */
-    private $analyses;
+    private $analyses = array();
 
+    /**
+     * @return Link[]
+     */
     public function getLinks()
     {
         return $this->links;
     }
 
+    /**
+     * @return Analysis[]
+     */
     public function getAnalyses()
     {
         return $this->analyses;

--- a/Sdk/Model/Analysis.php
+++ b/Sdk/Model/Analysis.php
@@ -27,7 +27,7 @@ class Analysis
      * @Type("array<SensioLabs\Insight\Sdk\Model\Link>")
      * @XmlList(inline = true, entry = "link")
      */
-    private $links;
+    private $links = array();
 
     /** @Type("integer") */
     private $number;
@@ -42,7 +42,7 @@ class Analysis
     private $nextGrade;
 
     /** @Type("array<string>") */
-    private $grades;
+    private $grades = array();
 
     /**
      * @Type("float")
@@ -110,96 +110,153 @@ class Analysis
     /** @Type("SensioLabs\Insight\Sdk\Model\Violations") */
     private $violations;
 
+    /**
+     * @return Link[]
+     */
     public function getLinks()
     {
         return $this->links;
     }
 
+    /**
+     * @return int
+     */
     public function getNumber()
     {
         return $this->number;
     }
 
+    /**
+     * @return string
+     */
     public function getGrade()
     {
         return $this->grade;
     }
 
+    /**
+     * @return string
+     */
     public function getNextGrade()
     {
         return $this->nextGrade;
     }
 
+    /**
+     * @return string[]
+     */
     public function getGrades()
     {
         return $this->grades;
     }
 
+    /**
+     * @return float
+     */
     public function getRemediationCost()
     {
         return $this->remediationCost;
     }
 
+    /**
+     * @return float
+     */
     public function getRemediationCostForNextGrade()
     {
         return $this->remediationCostForNextGrade;
     }
 
+    /**
+     * @return int
+     */
     public function getNbViolations()
     {
         return $this->nbViolations;
     }
 
+    /**
+     * @return \DateTime
+     */
     public function getBeginAt()
     {
         return $this->beginAt;
     }
 
+    /**
+     * @return \DateTime|null
+     */
     public function getEndAt()
     {
         return $this->endAt;
     }
 
+    /**
+     * @return \DateInterval
+     */
     public function getDuration()
     {
         return new \DateInterval('PT'.($this->duration ? $this->duration : '0').'S');
     }
 
+    /**
+     * @return string
+     */
     public function getFailureMessage()
     {
         return $this->failureMessage;
     }
 
+    /**
+     * @return string
+     */
     public function getFailureCode()
     {
         return $this->failureCode;
     }
 
+    /**
+     * @return bool
+     */
     public function isFailed()
     {
         return $this->failed;
     }
 
+    /**
+     * @return bool
+     */
     public function isFinished()
     {
         return static::STATUS_FINISHED == $this->status;
     }
 
+    /**
+     * @return string One of the STATUS_* constants
+     */
     public function getStatus()
     {
         return $this->status;
     }
 
+    /**
+     * @return string
+     */
     public function getStatusMessage()
     {
         return $this->statusMessage;
     }
 
+    /**
+     * @return bool
+     */
     public function isAltered()
     {
         return $this->isAltered;
     }
 
+    /**
+     * @return Violations
+     */
     public function getViolations()
     {
         return $this->violations;

--- a/Sdk/Model/Link.php
+++ b/Sdk/Model/Link.php
@@ -34,16 +34,25 @@ class Link
      */
     private $type;
 
+    /**
+     * @return string
+     */
     public function getHref()
     {
         return $this->href;
     }
 
+    /**
+     * @return string
+     */
     public function getRel()
     {
         return $this->rel;
     }
 
+    /**
+     * @return string
+     */
     public function getType()
     {
         return $this->type;

--- a/Sdk/Model/Project.php
+++ b/Sdk/Model/Project.php
@@ -52,7 +52,7 @@ class Project
      * @Type("array<SensioLabs\Insight\Sdk\Model\Link>")
      * @XmlList(inline = true, entry = "link")
      */
-    private $links;
+    private $links = array();
 
     /**
      * @Type("string")
@@ -105,16 +105,25 @@ class Project
         );
     }
 
+    /**
+     * @return Link[]
+     */
     public function getLinks()
     {
         return $this->links;
     }
 
+    /**
+     * @return string
+     */
     public function getUuid()
     {
         return $this->uuid;
     }
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return $this->name;
@@ -127,6 +136,9 @@ class Project
         return $this;
     }
 
+    /**
+     * @return string
+     */
     public function getConfiguration()
     {
         return $this->configuration;
@@ -139,6 +151,9 @@ class Project
         return $this;
     }
 
+    /**
+     * @return string
+     */
     public function getDescription()
     {
         return $this->description;
@@ -151,6 +166,9 @@ class Project
         return $this;
     }
 
+    /**
+     * @return int
+     */
     public function getType()
     {
         return $this->type;
@@ -167,6 +185,9 @@ class Project
         return $this;
     }
 
+    /**
+     * @return string
+     */
     public function getRepositoryUrl()
     {
         return $this->repositoryUrl;
@@ -179,6 +200,9 @@ class Project
         return $this;
     }
 
+    /**
+     * @return bool
+     */
     public function isPublic()
     {
         return !$this->private;
@@ -191,6 +215,9 @@ class Project
         return $this;
     }
 
+    /**
+     * @return bool
+     */
     public function isPrivate()
     {
         return $this->private;
@@ -203,11 +230,17 @@ class Project
         return $this;
     }
 
+    /**
+     * @return bool
+     */
     public function isReportAvailable()
     {
         return $this->reportAvailable;
     }
 
+    /**
+     * @return Analysis|null
+     */
     public function getLastAnalysis()
     {
         return $this->lastAnalysis;

--- a/Sdk/Model/Projects.php
+++ b/Sdk/Model/Projects.php
@@ -43,37 +43,51 @@ class Projects
      * @Type("array<SensioLabs\Insight\Sdk\Model\Link>")
      * @XmlList(inline = true, entry = "link")
      */
-    private $links;
+    private $links = array();
 
     /**
      * @Type("array<SensioLabs\Insight\Sdk\Model\Project>")
      * @XmlList(inline = true, entry = "project")
      */
-    private $projects;
+    private $projects = array();
 
+    /**
+     * @return int
+     */
     public function getPage()
     {
         return $this->page;
     }
 
+    /**
+     * @return int
+     */
     public function getTotal()
     {
         return $this->total;
     }
 
+    /**
+     * @return int
+     */
     public function getLimit()
     {
         return $this->limit;
     }
 
+    /**
+     * @return Link[]
+     */
     public function getLinks()
     {
         return $this->links;
     }
 
+    /**
+     * @return Project[]
+     */
     public function getProjects()
     {
         return $this->projects;
     }
-
 }

--- a/Sdk/Model/Violation.php
+++ b/Sdk/Model/Violation.php
@@ -40,31 +40,49 @@ class Violation
      */
     private $category;
 
+    /**
+     * @return string
+     */
     public function getTitle()
     {
         return $this->title;
     }
 
+    /**
+     * @return string
+     */
     public function getMessage()
     {
         return $this->message;
     }
 
+    /**
+     * @return string
+     */
     public function getResource()
     {
         return $this->resource;
     }
 
+    /**
+     * @return int
+     */
     public function getLine()
     {
         return $this->line;
     }
 
+    /**
+     * @return string
+     */
     public function getSeverity()
     {
         return $this->severity;
     }
 
+    /**
+     * @return string
+     */
     public function getCategory()
     {
         return $this->category;

--- a/Sdk/Model/Violations.php
+++ b/Sdk/Model/Violations.php
@@ -20,7 +20,7 @@ class Violations implements \Countable, \IteratorAggregate
      * @Type("array<SensioLabs\Insight\Sdk\Model\Violation>")
      * @XmlList(inline = true, entry = "violation")
      */
-    private $violations;
+    private $violations = array();
 
     public function count()
     {
@@ -32,6 +32,9 @@ class Violations implements \Countable, \IteratorAggregate
         return new \ArrayIterator($this->violations);
     }
 
+    /**
+     * @return Violation[]
+     */
     public function getViolations()
     {
         return $this->violations;

--- a/Sdk/Tests/ApiTest.php
+++ b/Sdk/Tests/ApiTest.php
@@ -19,8 +19,15 @@ use SensioLabs\Insight\Sdk\Model\Project;
 
 class ApiTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Api
+     */
     private $api;
     private $logger;
+
+    /**
+     * @var MockPlugin
+     */
     private $pluginMockResponse;
 
     public function setUp()

--- a/Sdk/Tests/ParserTest.php
+++ b/Sdk/Tests/ParserTest.php
@@ -15,6 +15,9 @@ use SensioLabs\Insight\Sdk\Parser;
 
 class ParserTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Parser
+     */
     private $parser;
 
     public function setUp()


### PR DESCRIPTION
This simplifies the usage of the SDK by allowing IDEs to provide autocompletion rather than having unknown types everywhere.

I also added the array initialization of array properties, to ensure that they are always arrays even if the serializer does not set them for some reason (the incomplete Analysis returned in `getAnalysisStatus` for instance).
