### PR TITLE
Fixed the location of the SSL certificate on Windows

### DIFF
--- a/Sdk/Api.php
+++ b/Sdk/Api.php
@@ -46,7 +46,7 @@ class Api
         );
         $requiredOptions = array('api_token', 'base_url', 'user_uuid');
         $options = Collection::fromConfig($options, $defaultOptions, $requiredOptions);
-        $this->client->setConfig($options);
+        $this->client->getConfig()->merge($options);
 
         $this->client->setBaseUrl($options->get('base_url'));
         $this->client->setDefaultHeaders(array(


### PR DESCRIPTION
Closes #34

The solution used here will work fine even when the tool is bundled as phar thanks to the Guzzle magic. However, people passing their own client will need to take care of making it SSL-capable themselves (which is an issue only for Windows, and maybe not at all on 5.6)
