### PR TITLE
Fix fail-condition option when a project has no violation

### DIFF
--- a/Cli/Command/AnalysisCommand.php
+++ b/Cli/Command/AnalysisCommand.php
@@ -57,17 +57,21 @@ class AnalysisCommand extends Command implements NeedConfigurationInterface
 
         $el = new ExpressionLanguage();
         $counts = array();
-        foreach ($analysis->getViolations() as $violation) {
-            if (!isset($counts[$violation->getCategory()])) {
-                $counts[$violation->getCategory()] = 0;
-            }
-            ++$counts[$violation->getCategory()];
 
-            if (!isset($counts[$violation->getSeverity()])) {
-                $counts[$violation->getSeverity()] = 0;
+        $violations = $analysis->getViolations();
+        if ($violations) {
+            foreach ($violations as $violation) {
+                if (!isset($counts[$violation->getCategory()])) {
+                    $counts[$violation->getCategory()] = 0;
+                }
+                ++$counts[$violation->getCategory()];
+
+                if (!isset($counts[$violation->getSeverity()])) {
+                    $counts[$violation->getSeverity()] = 0;
+                }
+                ++$counts[$violation->getSeverity()];
             }
-            ++$counts[$violation->getSeverity()];
-        };
+        }
         $vars = array(
            'analysis' => $analysis,
            'counts'   => (object) $counts,

--- a/Sdk/Model/Analysis.php
+++ b/Sdk/Model/Analysis.php
@@ -255,7 +255,7 @@ class Analysis
     }
 
     /**
-     * @return Violations
+     * @return Violations|null
      */
     public function getViolations()
     {


### PR DESCRIPTION
When you use the `--fail-condition` parameter of the `analysis` command and the project has no violation the following bug occurs:

```
php insight.phar analysis 87ec89e6-57cd-4ac0-9ab1-d4549c5425c5 --fail-condition="analysis.getGrade() != 'platinum'"

The project has 0 violations, it got the platinum grade.

Re-run this command with -v option to get the full report
PHP Warning:  Invalid argument supplied for foreach() in phar:///var/lib/jenkins/insight.phar/SensioLabs/Insight/Cli/Command/AnalysisCommand.php on line 60
jenkins
```

This PR fixes it.
