### PR TITLE
Fix PmdDescriptor

### DIFF
--- a/Cli/Descriptor/PmdDescriptor.php
+++ b/Cli/Descriptor/PmdDescriptor.php
@@ -28,31 +28,34 @@ class PmdDescriptor extends AbstractDescriptor
 
         $xml->appendChild($pmd);
 
-        foreach ($analysis->getViolations() as $violation) {
-            /**
-             * @var $violation \SensioLabs\Insight\Sdk\Model\Violation
-             */
-            $filename = $violation->getResource();
+        $violations = $analysis->getViolations();
+        if ($violations) {
+            foreach ($violations as $violation) {
+                /**
+                 * @var $violation \SensioLabs\Insight\Sdk\Model\Violation
+                 */
+                $filename = $violation->getResource();
 
-            $nodes = $xpath->query(sprintf('//file[@name="%s"]', $filename));
+                $nodes = $xpath->query(sprintf('//file[@name="%s"]', $filename));
 
-            if ($nodes->length > 0) {
-                $node = $nodes->item(0);
-            } else {
-                $node = $xml->createElement('file');
-                $node->setAttribute('name', $filename);
+                if ($nodes->length > 0) {
+                    $node = $nodes->item(0);
+                } else {
+                    $node = $xml->createElement('file');
+                    $node->setAttribute('name', $filename);
 
-                $pmd->appendChild($node);
+                    $pmd->appendChild($node);
+                }
+
+                $violationNode = $xml->createElement('violation', $violation->getMessage());
+                $node->appendChild($violationNode);
+
+                $violationNode->setAttribute('beginline', $violation->getLine());
+                $violationNode->setAttribute('endline',   $violation->getLine());
+                $violationNode->setAttribute('rule',      $violation->getTitle());
+                $violationNode->setAttribute('ruleset',   $violation->getCategory());
+                $violationNode->setAttribute('priority',  $this->getPriority($violation));
             }
-
-            $violationNode = $xml->createElement('violation', $violation->getMessage());
-            $node->appendChild($violationNode);
-
-            $violationNode->setAttribute('beginline', $violation->getLine());
-            $violationNode->setAttribute('endline',   $violation->getLine());
-            $violationNode->setAttribute('rule',      $violation->getTitle());
-            $violationNode->setAttribute('ruleset',   $violation->getCategory());
-            $violationNode->setAttribute('priority',  $this->getPriority($violation));
         }
 
         $output->writeln($xml->saveXML());


### PR DESCRIPTION
A PHP warning is displayed when using the PMD format on a project with no violations:

``` xml
$ php insight.phar analysis d7d70442-b52c-4072-8e03-45e6a47e1ca2 --format="pmd"
PHP Warning:  Invalid argument supplied for foreach() in phar:///var/lib/jenkins/insight.phar/SensioLabs/Insight/Cli/Descriptor/PmdDescriptor.php on line 31
<?xml version="1.0" encoding="UTF-8"?>
<pmd timestamp="2014-11-16T11:15:54+01:00"/>
```

This PR fix this bug.
