### PR TITLE
Prepare version 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,109 @@
+version: 2
+
+jobs:
+    php-cs:
+        docker:
+            - image: php:7.2-cli-alpine3.7
+        steps:
+            - checkout
+            - run: wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.13.1/php-cs-fixer.phar
+            - run: php php-cs-fixer.phar fix --dry-run --diff
+
+    tests-php-7-1:
+        docker:
+            - image: php:7.1-cli-alpine3.7
+        steps:
+            - checkout
+
+            # Composer
+            - restore_cache:
+                  keys:
+                      - v1-deps-{{ checksum "composer.lock" }}
+            - run: composer install
+            - save_cache:
+                  paths: [./vendor]
+                  key: v1-deps-{{ checksum "composer.lock" }}
+
+            # Prepare PHPUnit bridge
+            - restore_cache:
+                  keys:
+                      - v1-phpunit-{{ checksum "composer.lock" }}
+            - run: php vendor/bin/simple-phpunit --check-version
+            - save_cache:
+                  paths: [./bin/.phpunit]
+                  key: v1-phpunit-{{ checksum "composer.lock" }}
+
+            # Launch the test suite
+            - run: php vendor/bin/simple-phpunit -v --log-junit ./phpunit/junit.xml
+
+            - store_test_results:
+                  path: ./phpunit
+
+    tests-php-7-2:
+        docker:
+            - image: php:7.2-cli-alpine3.7
+        steps:
+            - checkout
+
+            # Composer
+            - restore_cache:
+                  keys:
+                      - v1-deps-{{ checksum "composer.lock" }}
+            - run: composer install
+            - save_cache:
+                  paths: [./vendor]
+                  key: v1-deps-{{ checksum "composer.lock" }}
+
+            # Prepare PHPUnit bridge
+            - restore_cache:
+                  keys:
+                      - v1-phpunit-{{ checksum "composer.lock" }}
+            - run: php vendor/bin/simple-phpunit --check-version
+            - save_cache:
+                  paths: [./bin/.phpunit]
+                  key: v1-phpunit-{{ checksum "composer.lock" }}
+
+            # Launch the test suite
+            - run: php vendor/bin/simple-phpunit -v --log-junit ./phpunit/junit.xml
+
+            - store_test_results:
+                  path: ./phpunit
+
+    tests-php-7-3:
+        docker:
+            - image: php:7.3-cli-alpine3.7
+        steps:
+            - checkout
+
+            # Composer
+            - restore_cache:
+                  keys:
+                      - v1-deps-{{ checksum "composer.lock" }}
+            - run: composer install
+            - save_cache:
+                  paths: [./vendor]
+                  key: v1-deps-{{ checksum "composer.lock" }}
+
+            # Prepare PHPUnit bridge
+            - restore_cache:
+                  keys:
+                      - v1-phpunit-{{ checksum "composer.lock" }}
+            - run: php vendor/bin/simple-phpunit --check-version
+            - save_cache:
+                  paths: [./bin/.phpunit]
+                  key: v1-phpunit-{{ checksum "composer.lock" }}
+
+            # Launch the test suite
+            - run: php vendor/bin/simple-phpunit -v --log-junit ./phpunit/junit.xml
+
+            - store_test_results:
+                  path: ./phpunit
+
+workflows:
+    version: 2
+    test:
+        jobs:
+            - php-cs
+            - tests-php-7-1
+            - tests-php-7-2
+            - tests-php-7-3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
     php-cs:
         docker:
-            - image: php:7.2-cli-alpine3.7
+            - image: php:7.2-cli-alpine
         steps:
             - checkout
             - run: wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.13.1/php-cs-fixer.phar
@@ -11,27 +11,28 @@ jobs:
 
     tests-php-7-1:
         docker:
-            - image: php:7.1-cli-alpine3.7
+            - image: php:7.1-cli-alpine
         steps:
             - checkout
 
             # Composer
+            - run: wget https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer -O - -q | php -- --quiet
             - restore_cache:
                   keys:
-                      - v1-deps-{{ checksum "composer.lock" }}
-            - run: composer install
+                      - v1-deps-{{ checksum "composer.json" }}
+            - run: php composer.phar install
             - save_cache:
                   paths: [./vendor]
-                  key: v1-deps-{{ checksum "composer.lock" }}
+                  key: v1-deps-{{ checksum "composer.json" }}
 
             # Prepare PHPUnit bridge
             - restore_cache:
                   keys:
-                      - v1-phpunit-{{ checksum "composer.lock" }}
-            - run: php vendor/bin/simple-phpunit --check-version
+                      - v1-phpunit-{{ checksum "composer.json" }}
+            - run: php vendor/bin/simple-phpunit install
             - save_cache:
                   paths: [./bin/.phpunit]
-                  key: v1-phpunit-{{ checksum "composer.lock" }}
+                  key: v1-phpunit-{{ checksum "composer.json" }}
 
             # Launch the test suite
             - run: php vendor/bin/simple-phpunit -v --log-junit ./phpunit/junit.xml
@@ -41,27 +42,28 @@ jobs:
 
     tests-php-7-2:
         docker:
-            - image: php:7.2-cli-alpine3.7
+            - image: php:7.2-cli-alpine
         steps:
             - checkout
 
             # Composer
+            - run: wget https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer -O - -q | php -- --quiet
             - restore_cache:
                   keys:
-                      - v1-deps-{{ checksum "composer.lock" }}
-            - run: composer install
+                      - v1-deps-{{ checksum "composer.json" }}
+            - run: php composer.phar install
             - save_cache:
                   paths: [./vendor]
-                  key: v1-deps-{{ checksum "composer.lock" }}
+                  key: v1-deps-{{ checksum "composer.json" }}
 
             # Prepare PHPUnit bridge
             - restore_cache:
                   keys:
-                      - v1-phpunit-{{ checksum "composer.lock" }}
-            - run: php vendor/bin/simple-phpunit --check-version
+                      - v1-phpunit-{{ checksum "composer.json" }}
+            - run: php vendor/bin/simple-phpunit install
             - save_cache:
                   paths: [./bin/.phpunit]
-                  key: v1-phpunit-{{ checksum "composer.lock" }}
+                  key: v1-phpunit-{{ checksum "composer.json" }}
 
             # Launch the test suite
             - run: php vendor/bin/simple-phpunit -v --log-junit ./phpunit/junit.xml
@@ -71,27 +73,28 @@ jobs:
 
     tests-php-7-3:
         docker:
-            - image: php:7.3-cli-alpine3.7
+            - image: php:7.3-cli-alpine
         steps:
             - checkout
 
             # Composer
+            - run: wget https://raw.githubusercontent.com/composer/getcomposer.org/76a7060ccb93902cd7576b67264ad91c8a2700e2/web/installer -O - -q | php -- --quiet
             - restore_cache:
                   keys:
-                      - v1-deps-{{ checksum "composer.lock" }}
-            - run: composer install
+                      - v1-deps-{{ checksum "composer.json" }}
+            - run: php composer.phar install
             - save_cache:
                   paths: [./vendor]
-                  key: v1-deps-{{ checksum "composer.lock" }}
+                  key: v1-deps-{{ checksum "composer.json" }}
 
             # Prepare PHPUnit bridge
             - restore_cache:
                   keys:
-                      - v1-phpunit-{{ checksum "composer.lock" }}
-            - run: php vendor/bin/simple-phpunit --check-version
+                      - v1-phpunit-{{ checksum "composer.json" }}
+            - run: php vendor/bin/simple-phpunit install
             - save_cache:
                   paths: [./bin/.phpunit]
-                  key: v1-phpunit-{{ checksum "composer.lock" }}
+                  key: v1-phpunit-{{ checksum "composer.json" }}
 
             # Launch the test suite
             - run: php vendor/bin/simple-phpunit -v --log-junit ./phpunit/junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /build/
 /insight.log
 /vendor/
+/.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,16 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in('bin')
+    ->in('Cli')
+    ->in('Sdk')
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        '@Symfony' => true,
+        'array_syntax' => ['syntax' => 'long'],
+        'phpdoc_annotation_without_dot' => false,
+    ])
+    ->setFinder($finder)
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,6 @@ script:
 
 jobs:
   include:
-    - stage: test
-      php: 5.3
-      dist: precise
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
-    - php: 7.0
     - php: 7.1
     - php: 7.2
     - php: 7.3

--- a/Cli/Application.php
+++ b/Cli/Application.php
@@ -1,22 +1,22 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli;
+namespace Symfony\Insight\Cli;
 
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
-use SensioLabs\Insight\Cli\Command as LocalCommand;
-use SensioLabs\Insight\Cli\Helper\ConfigurationHelper;
-use SensioLabs\Insight\Cli\Helper\FailConditionHelper;
-use SensioLabs\Insight\Sdk\Api;
+use Symfony\Insight\Cli\Command as LocalCommand;
+use Symfony\Insight\Cli\Helper\ConfigurationHelper;
+use Symfony\Insight\Cli\Helper\FailConditionHelper;
+use Symfony\Insight\Sdk\Api;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -25,8 +25,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class Application extends SymfonyApplication
 {
-    const APPLICATION_NAME = 'SensioLabs Insight CLI';
-    const APPLICATION_VERSION = '1.6-dev';
+    const APPLICATION_NAME = 'SymfonyInsight CLI';
+    const APPLICATION_VERSION = '2.0';
 
     private $api;
     private $apiConfig;
@@ -68,7 +68,7 @@ class Application extends SymfonyApplication
 
     public function getLongVersion()
     {
-        $version = parent::getLongVersion().' by <comment>SensioLabs</comment>';
+        $version = parent::getLongVersion().' by <comment>Symfony</comment>';
         $commit = '@git-commit@';
 
         if ('@'.'git-commit@' !== $commit) {

--- a/Cli/Application.php
+++ b/Cli/Application.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli;
+namespace SymfonyCorp\Insight\Cli;
 
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
-use Symfony\Insight\Cli\Command as LocalCommand;
-use Symfony\Insight\Cli\Helper\ConfigurationHelper;
-use Symfony\Insight\Cli\Helper\FailConditionHelper;
-use Symfony\Insight\Sdk\Api;
+use SymfonyCorp\Insight\Cli\Command as LocalCommand;
+use SymfonyCorp\Insight\Cli\Helper\ConfigurationHelper;
+use SymfonyCorp\Insight\Cli\Helper\FailConditionHelper;
+use SymfonyCorp\Insight\Sdk\Api;
 use Symfony\Component\Console\Application as SymfonyApplication;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Cli/Command/AnalysisCommand.php
+++ b/Cli/Command/AnalysisCommand.php
@@ -1,17 +1,17 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli\Command;
+namespace Symfony\Insight\Cli\Command;
 
-use SensioLabs\Insight\Cli\Helper\DescriptorHelper;
+use Symfony\Insight\Cli\Helper\DescriptorHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Cli/Command/AnalysisCommand.php
+++ b/Cli/Command/AnalysisCommand.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli\Command;
+namespace SymfonyCorp\Insight\Cli\Command;
 
-use Symfony\Insight\Cli\Helper\DescriptorHelper;
+use SymfonyCorp\Insight\Cli\Helper\DescriptorHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -52,7 +52,7 @@ class AnalysisCommand extends Command implements NeedConfigurationInterface
         }
 
         if (!$expr = $input->getOption('fail-condition')) {
-            return;
+            return 0;
         }
 
         return $this->getHelperSet()->get('fail_condition')->evaluate($analysis, $expr);

--- a/Cli/Command/AnalyzeCommand.php
+++ b/Cli/Command/AnalyzeCommand.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli\Command;
+namespace SymfonyCorp\Insight\Cli\Command;
 
-use Symfony\Insight\Cli\Helper\DescriptorHelper;
+use SymfonyCorp\Insight\Cli\Helper\DescriptorHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -87,7 +87,7 @@ class AnalyzeCommand extends Command implements NeedConfigurationInterface
         }
 
         if (!$expr = $input->getOption('fail-condition')) {
-            return;
+            return 0;
         }
 
         return $this->getHelperSet()->get('fail_condition')->evaluate($analysis, $expr);

--- a/Cli/Command/AnalyzeCommand.php
+++ b/Cli/Command/AnalyzeCommand.php
@@ -1,17 +1,17 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli\Command;
+namespace Symfony\Insight\Cli\Command;
 
-use SensioLabs\Insight\Cli\Helper\DescriptorHelper;
+use Symfony\Insight\Cli\Helper\DescriptorHelper;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Cli/Command/ConfigureCommand.php
+++ b/Cli/Command/ConfigureCommand.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli\Command;
+namespace SymfonyCorp\Insight\Cli\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Cli/Command/ConfigureCommand.php
+++ b/Cli/Command/ConfigureCommand.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli\Command;
+namespace Symfony\Insight\Cli\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Cli/Command/NeedConfigurationInterface.php
+++ b/Cli/Command/NeedConfigurationInterface.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli\Command;
+namespace Symfony\Insight\Cli\Command;
 
 interface NeedConfigurationInterface
 {

--- a/Cli/Command/NeedConfigurationInterface.php
+++ b/Cli/Command/NeedConfigurationInterface.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli\Command;
+namespace SymfonyCorp\Insight\Cli\Command;
 
 interface NeedConfigurationInterface
 {

--- a/Cli/Command/ProjectsCommand.php
+++ b/Cli/Command/ProjectsCommand.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli\Command;
+namespace SymfonyCorp\Insight\Cli\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Cli/Command/ProjectsCommand.php
+++ b/Cli/Command/ProjectsCommand.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli\Command;
+namespace Symfony\Insight\Cli\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Cli/Command/SelfUpdateCommand.php
+++ b/Cli/Command/SelfUpdateCommand.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli\Command;
+namespace Symfony\Insight\Cli\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -46,7 +46,7 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $remoteFilename = 'http://get.insight.sensiolabs.com/insight.phar';
+        $remoteFilename = 'https://get.insight.symfony.com/insight.phar';
         $localFilename = $_SERVER['argv'][0];
         $tempFilename = basename($localFilename, '.phar').'-temp.phar';
 

--- a/Cli/Command/SelfUpdateCommand.php
+++ b/Cli/Command/SelfUpdateCommand.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli\Command;
+namespace SymfonyCorp\Insight\Cli\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;

--- a/Cli/Configuration.php
+++ b/Cli/Configuration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Symfony\Insight\Cli;
+namespace SymfonyCorp\Insight\Cli;
 
 class Configuration
 {

--- a/Cli/Configuration.php
+++ b/Cli/Configuration.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SensioLabs\Insight\Cli;
+namespace Symfony\Insight\Cli;
 
 class Configuration
 {

--- a/Cli/Descriptor/AbstractDescriptor.php
+++ b/Cli/Descriptor/AbstractDescriptor.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli\Descriptor;
+namespace SymfonyCorp\Insight\Cli\Descriptor;
 
-use Symfony\Insight\Sdk\Model\Analysis;
-use Symfony\Insight\Sdk\Model\Violation;
+use SymfonyCorp\Insight\Sdk\Model\Analysis;
+use SymfonyCorp\Insight\Sdk\Model\Violation;
 
 abstract class AbstractDescriptor
 {

--- a/Cli/Descriptor/AbstractDescriptor.php
+++ b/Cli/Descriptor/AbstractDescriptor.php
@@ -1,18 +1,18 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli\Descriptor;
+namespace Symfony\Insight\Cli\Descriptor;
 
-use SensioLabs\Insight\Sdk\Model\Analysis;
-use SensioLabs\Insight\Sdk\Model\Violation;
+use Symfony\Insight\Sdk\Model\Analysis;
+use Symfony\Insight\Sdk\Model\Violation;
 
 abstract class AbstractDescriptor
 {

--- a/Cli/Descriptor/JsonDescriptor.php
+++ b/Cli/Descriptor/JsonDescriptor.php
@@ -1,18 +1,18 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli\Descriptor;
+namespace Symfony\Insight\Cli\Descriptor;
 
 use JMS\Serializer\Serializer;
-use SensioLabs\Insight\Sdk\Model\Analysis;
+use Symfony\Insight\Sdk\Model\Analysis;
 
 class JsonDescriptor extends AbstractDescriptor
 {

--- a/Cli/Descriptor/JsonDescriptor.php
+++ b/Cli/Descriptor/JsonDescriptor.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli\Descriptor;
+namespace SymfonyCorp\Insight\Cli\Descriptor;
 
 use JMS\Serializer\Serializer;
-use Symfony\Insight\Sdk\Model\Analysis;
+use SymfonyCorp\Insight\Sdk\Model\Analysis;
 
 class JsonDescriptor extends AbstractDescriptor
 {

--- a/Cli/Descriptor/PmdDescriptor.php
+++ b/Cli/Descriptor/PmdDescriptor.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Symfony\Insight\Cli\Descriptor;
+namespace SymfonyCorp\Insight\Cli\Descriptor;
 
-use Symfony\Insight\Sdk\Model\Analysis;
-use Symfony\Insight\Sdk\Model\Violation;
+use SymfonyCorp\Insight\Sdk\Model\Analysis;
+use SymfonyCorp\Insight\Sdk\Model\Violation;
 
 class PmdDescriptor extends AbstractDescriptor
 {
@@ -32,7 +32,7 @@ class PmdDescriptor extends AbstractDescriptor
         if ($violations) {
             foreach ($violations as $violation) {
                 /*
-                 * @var $violation \Symfony\Insight\Sdk\Model\Violation
+                 * @var $violation \SymfonyCorp\Insight\Sdk\Model\Violation
                  */
                 $filename = $violation->getResource();
 

--- a/Cli/Descriptor/PmdDescriptor.php
+++ b/Cli/Descriptor/PmdDescriptor.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace SensioLabs\Insight\Cli\Descriptor;
+namespace Symfony\Insight\Cli\Descriptor;
 
-use SensioLabs\Insight\Sdk\Model\Analysis;
-use SensioLabs\Insight\Sdk\Model\Violation;
+use Symfony\Insight\Sdk\Model\Analysis;
+use Symfony\Insight\Sdk\Model\Violation;
 
 class PmdDescriptor extends AbstractDescriptor
 {
@@ -32,7 +32,7 @@ class PmdDescriptor extends AbstractDescriptor
         if ($violations) {
             foreach ($violations as $violation) {
                 /*
-                 * @var $violation \SensioLabs\Insight\Sdk\Model\Violation
+                 * @var $violation \Symfony\Insight\Sdk\Model\Violation
                  */
                 $filename = $violation->getResource();
 

--- a/Cli/Descriptor/TextDescriptor.php
+++ b/Cli/Descriptor/TextDescriptor.php
@@ -1,17 +1,17 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli\Descriptor;
+namespace Symfony\Insight\Cli\Descriptor;
 
-use SensioLabs\Insight\Sdk\Model\Analysis;
+use Symfony\Insight\Sdk\Model\Analysis;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class TextDescriptor extends AbstractDescriptor

--- a/Cli/Descriptor/TextDescriptor.php
+++ b/Cli/Descriptor/TextDescriptor.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli\Descriptor;
+namespace SymfonyCorp\Insight\Cli\Descriptor;
 
-use Symfony\Insight\Sdk\Model\Analysis;
+use SymfonyCorp\Insight\Sdk\Model\Analysis;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class TextDescriptor extends AbstractDescriptor

--- a/Cli/Descriptor/XmlDescriptor.php
+++ b/Cli/Descriptor/XmlDescriptor.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli\Descriptor;
+namespace SymfonyCorp\Insight\Cli\Descriptor;
 
 use JMS\Serializer\Serializer;
-use Symfony\Insight\Sdk\Model\Analysis;
+use SymfonyCorp\Insight\Sdk\Model\Analysis;
 
 class XmlDescriptor extends AbstractDescriptor
 {

--- a/Cli/Descriptor/XmlDescriptor.php
+++ b/Cli/Descriptor/XmlDescriptor.php
@@ -1,18 +1,18 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli\Descriptor;
+namespace Symfony\Insight\Cli\Descriptor;
 
 use JMS\Serializer\Serializer;
-use SensioLabs\Insight\Sdk\Model\Analysis;
+use Symfony\Insight\Sdk\Model\Analysis;
 
 class XmlDescriptor extends AbstractDescriptor
 {

--- a/Cli/Helper/ConfigurationHelper.php
+++ b/Cli/Helper/ConfigurationHelper.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace SensioLabs\Insight\Cli\Helper;
+namespace Symfony\Insight\Cli\Helper;
 
-use SensioLabs\Insight\Cli\Configuration;
+use Symfony\Insight\Cli\Configuration;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/Cli/Helper/ConfigurationHelper.php
+++ b/Cli/Helper/ConfigurationHelper.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Symfony\Insight\Cli\Helper;
+namespace SymfonyCorp\Insight\Cli\Helper;
 
-use Symfony\Insight\Cli\Configuration;
+use SymfonyCorp\Insight\Cli\Configuration;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/Cli/Helper/DescriptorHelper.php
+++ b/Cli/Helper/DescriptorHelper.php
@@ -1,22 +1,22 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli\Helper;
+namespace Symfony\Insight\Cli\Helper;
 
 use JMS\Serializer\Serializer;
-use SensioLabs\Insight\Cli\Descriptor\AbstractDescriptor;
-use SensioLabs\Insight\Cli\Descriptor\JsonDescriptor;
-use SensioLabs\Insight\Cli\Descriptor\PmdDescriptor;
-use SensioLabs\Insight\Cli\Descriptor\TextDescriptor;
-use SensioLabs\Insight\Cli\Descriptor\XmlDescriptor;
+use Symfony\Insight\Cli\Descriptor\AbstractDescriptor;
+use Symfony\Insight\Cli\Descriptor\JsonDescriptor;
+use Symfony\Insight\Cli\Descriptor\PmdDescriptor;
+use Symfony\Insight\Cli\Descriptor\TextDescriptor;
+use Symfony\Insight\Cli\Descriptor\XmlDescriptor;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/Cli/Helper/DescriptorHelper.php
+++ b/Cli/Helper/DescriptorHelper.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli\Helper;
+namespace SymfonyCorp\Insight\Cli\Helper;
 
 use JMS\Serializer\Serializer;
-use Symfony\Insight\Cli\Descriptor\AbstractDescriptor;
-use Symfony\Insight\Cli\Descriptor\JsonDescriptor;
-use Symfony\Insight\Cli\Descriptor\PmdDescriptor;
-use Symfony\Insight\Cli\Descriptor\TextDescriptor;
-use Symfony\Insight\Cli\Descriptor\XmlDescriptor;
+use SymfonyCorp\Insight\Cli\Descriptor\AbstractDescriptor;
+use SymfonyCorp\Insight\Cli\Descriptor\JsonDescriptor;
+use SymfonyCorp\Insight\Cli\Descriptor\PmdDescriptor;
+use SymfonyCorp\Insight\Cli\Descriptor\TextDescriptor;
+use SymfonyCorp\Insight\Cli\Descriptor\XmlDescriptor;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/Cli/Helper/FailConditionHelper.php
+++ b/Cli/Helper/FailConditionHelper.php
@@ -1,17 +1,17 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Cli\Helper;
+namespace Symfony\Insight\Cli\Helper;
 
-use SensioLabs\Insight\Sdk\Model\Analysis;
+use Symfony\Insight\Sdk\Model\Analysis;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 

--- a/Cli/Helper/FailConditionHelper.php
+++ b/Cli/Helper/FailConditionHelper.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Cli\Helper;
+namespace SymfonyCorp\Insight\Cli\Helper;
 
-use Symfony\Insight\Sdk\Model\Analysis;
+use SymfonyCorp\Insight\Sdk\Model\Analysis;
 use Symfony\Component\Console\Helper\Helper;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013 SensioLabs
+Copyright (c) 2013 Symfony
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-SensioLabsInsight SDK
-=====================
+SymfonyInsight SDK
+==================
 
 About
 -----
 
-This is the official SDK for the SensioLabsInsight API.
+This is the official SDK for the SymfonyInsight API.
 
 Installation
 ------------
@@ -16,15 +16,15 @@ To install the SDK, run the command below and you will get the latest version:
 Command Line Tool
 -----------------
 
-The easiest way to use the SensioLabsInsight API is via the built-in command
+The easiest way to use the SymfonyInsight API is via the built-in command
 line tool.
 
 A phar version of the command line tool exists to avoid installation of this
 project. Download it, then use it like the command line tool:
 
-    $ curl -o insight.phar -s http://get.insight.sensiolabs.com/insight.phar
+    $ curl -o insight.phar -s https://get.insight.symfony.com/insight.phar
     # or
-    $ wget http://get.insight.sensiolabs.com/insight.phar
+    $ wget https://get.insight.symfony.com/insight.phar
 
     # Then
     $ php insight.phar
@@ -33,7 +33,7 @@ List all the projects in your account:
 
     $ php insight.phar projects
 
-The first time, you will be prompted for your SensioLabsInsight API key and
+The first time, you will be prompted for your SymfonyInsight API key and
 user UUID (which can be found under the "Account" section on the website).
 These information are then stored locally, but can still be overridden via the
 `--api-token` and `--user-uuid` options.
@@ -52,7 +52,7 @@ To export an analysis report:
 Configuration
 -------------
 
-    use SensioLabs\Insight\Sdk\Api;
+    use Symfony\Insight\Sdk\Api;
 
     $api = new Api(array(
         'api_token' => 'your api token',
@@ -108,7 +108,7 @@ Note: If something went wrong, see *Error management* section
 
 ### Post a project
 
-    use SensioLabs\Insight\Sdk\Model\Project;
+    use Symfony\Insight\Sdk\Model\Project;
 
     $project = new Project();
     $project
@@ -144,26 +144,26 @@ Note: If something went wrong, see *Error management* section
 ### Error management
 
 If something went wrong, an
-`SensioLabs\Insight\Sdk\Exception\ExceptionInterface` will be throw:
+`Symfony\Insight\Sdk\Exception\ExceptionInterface` will be throw:
 
 * `ApiClientException` If you did something wrong. This exception contains the
   previous exception throw by guzzle. You can easily check if it is a:
   * 403: In this case, check your credentials
   * 404: In this case, check your request
   * 400: In this case, check the data sent. In this case, the Exception will
-    contains a `SensioLabs\Insight\Sdk\Model\Error` object. Which will contains
+    contains a `Symfony\Insight\Sdk\Model\Error` object. Which will contains
     all form errors.
 * `ApiServerException` If something went wrong with the API.
 
 Jenkins/Hudson Integration
 --------------------------
-Thanks to [Jenkins PMD Plugin](https://wiki.jenkins-ci.org/display/JENKINS/PMD+Plugin) and SensioLabsInsight SDK PMD output you can easily
-embed SensioLabsInsight reports into your build workflow, following these steps:
+Thanks to [Jenkins PMD Plugin](https://wiki.jenkins-ci.org/display/JENKINS/PMD+Plugin) and SymfonyInsight SDK PMD output you can easily
+embed SymfonyInsight reports into your build workflow, following these steps:
 
-*It is assumed you already have your project up and building in Jenkins and SensioLabsInsight SDK installed*
+*It is assumed you already have your project up and building in Jenkins and SymfonyInsight SDK installed*
 
-1. Retrieve your `SensioLabsInsight API Token`, `User UUID` and `Project UUID`
-on your [account page](https://insight.sensiolabs.com/account)
+1. Retrieve your `SymfonyInsight API Token`, `User UUID` and `Project UUID`
+on your [account page](https://insight.symfony.com/account)
 2. Install the Jenkins `PMD plugin`:
 [How to install a jenkins plugin](https://wiki.jenkins-ci.org/display/JENKINS/Plugins#Plugins-Howtoinstallplugins)
 3. Optionally you can also install the `EnvInject  Plugin`

--- a/README.md
+++ b/README.md
@@ -1,17 +1,40 @@
-SymfonyInsight SDK
-==================
+<p align="center"><a href="https://insight.symfony.com" target="_blank">
+    <img src="https://symfony.com/logos/symfony_black_02.svg">
+</a></p>
 
-About
------
+<p align="center">
+    Build high quality projects. Monitor technical debt efficiently.
+</p>
 
-This is the official SDK for the SymfonyInsight API.
+[SymfonyInsight][https://insight.symfony.com] is a **PHP static and dynamic analysis**
+platform, especially well suited to analyse Symfony projects. It helps you monitor and pay back
+technical debt efficiently and it alerts you on critically low levels of quality.
+
+This repository is a PHP SDK and command-line tool you can use to trigger analysis and access
+data from SymfonyInsight in your own infrastructure.
 
 Installation
 ------------
 
-To install the SDK, run the command below and you will get the latest version:
+**Command-line tool installation**
 
-    composer require sensiolabs/insight
+To install the command-line tool, you can download it directly from our servers:
+
+```
+curl -o insight.phar -s http://get.insight.sensiolabs.com/insight.phar
+# or
+wget http://get.insight.sensiolabs.com/insight.phar
+
+php insight.phar
+```
+
+**SDK installation**
+
+To install the SDK, use Composer:
+
+```
+composer require symfonycorp/insight
+```
 
 Command Line Tool
 -----------------
@@ -157,6 +180,7 @@ If something went wrong, an
 
 Jenkins/Hudson Integration
 --------------------------
+
 Thanks to [Jenkins PMD Plugin](https://wiki.jenkins-ci.org/display/JENKINS/PMD+Plugin) and SymfonyInsight SDK PMD output you can easily
 embed SymfonyInsight reports into your build workflow, following these steps:
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To export an analysis report:
 Configuration
 -------------
 
-    use Symfony\Insight\Sdk\Api;
+    use SymfonyCorp\Insight\Sdk\Api;
 
     $api = new Api(array(
         'api_token' => 'your api token',
@@ -108,7 +108,7 @@ Note: If something went wrong, see *Error management* section
 
 ### Post a project
 
-    use Symfony\Insight\Sdk\Model\Project;
+    use SymfonyCorp\Insight\Sdk\Model\Project;
 
     $project = new Project();
     $project
@@ -144,14 +144,14 @@ Note: If something went wrong, see *Error management* section
 ### Error management
 
 If something went wrong, an
-`Symfony\Insight\Sdk\Exception\ExceptionInterface` will be throw:
+`SymfonyCorp\Insight\Sdk\Exception\ExceptionInterface` will be throw:
 
 * `ApiClientException` If you did something wrong. This exception contains the
   previous exception throw by guzzle. You can easily check if it is a:
   * 403: In this case, check your credentials
   * 404: In this case, check your request
   * 400: In this case, check the data sent. In this case, the Exception will
-    contains a `Symfony\Insight\Sdk\Model\Error` object. Which will contains
+    contains a `SymfonyCorp\Insight\Sdk\Model\Error` object. Which will contains
     all form errors.
 * `ApiServerException` If something went wrong with the API.
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 <p align="center"><a href="https://insight.symfony.com" target="_blank">
-    <img src="https://symfony.com/logos/symfony_black_02.svg">
+    <img src="https://insight.symfony.com/bundles/insight/img/logo-github-sdk.svg">
 </a></p>
 
 <p align="center">
-    Build high quality projects. Monitor technical debt efficiently.
+    <strong>Build high quality projects. Monitor technical debt efficiently.</strong>
 </p>
 
-[SymfonyInsight][https://insight.symfony.com] is a **PHP static and dynamic analysis**
+<br />
+
+
+[SymfonyInsight](https://insight.symfony.com) is a **PHP static and dynamic analysis**
 platform, especially well suited to analyse Symfony projects. It helps you monitor and pay back
 technical debt efficiently and it alerts you on critically low levels of quality.
 
@@ -18,13 +21,18 @@ Installation
 
 **Command-line tool installation**
 
-To install the command-line tool, you can download it directly from our servers:
+The easiest way to use the SymfonyInsight API is via the built-in command
+line tool. A PHAR version of the command line tool exists to avoid 
+having to install this project.
+
+To install this command line tool, you can download it directly from our servers:
 
 ```
-curl -o insight.phar -s http://get.insight.sensiolabs.com/insight.phar
+curl -o insight.phar -s https://get.insight.symfony.com/insight.phar
 # or
-wget http://get.insight.sensiolabs.com/insight.phar
+wget https://get.insight.symfony.com/insight.phar
 
+# Then
 php insight.phar
 ```
 
@@ -38,19 +46,6 @@ composer require symfonycorp/insight
 
 Command Line Tool
 -----------------
-
-The easiest way to use the SymfonyInsight API is via the built-in command
-line tool.
-
-A phar version of the command line tool exists to avoid installation of this
-project. Download it, then use it like the command line tool:
-
-    $ curl -o insight.phar -s https://get.insight.symfony.com/insight.phar
-    # or
-    $ wget https://get.insight.symfony.com/insight.phar
-
-    # Then
-    $ php insight.phar
 
 List all the projects in your account:
 

--- a/Sdk/Api.php
+++ b/Sdk/Api.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk;
+namespace Symfony\Insight\Sdk;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Guzzle\Common\Collection;
@@ -20,16 +20,16 @@ use Guzzle\Http\Message\RequestInterface;
 use JMS\Serializer\Serializer;
 use JMS\Serializer\SerializerBuilder;
 use Psr\Log\LoggerInterface;
-use SensioLabs\Insight\Sdk\Exception\ApiClientException;
-use SensioLabs\Insight\Sdk\Exception\ApiServerException;
-use SensioLabs\Insight\Sdk\Model\Analyses;
-use SensioLabs\Insight\Sdk\Model\Analysis;
-use SensioLabs\Insight\Sdk\Model\Project;
-use SensioLabs\Insight\Sdk\Model\Projects;
+use Symfony\Insight\Sdk\Exception\ApiClientException;
+use Symfony\Insight\Sdk\Exception\ApiServerException;
+use Symfony\Insight\Sdk\Model\Analyses;
+use Symfony\Insight\Sdk\Model\Analysis;
+use Symfony\Insight\Sdk\Model\Project;
+use Symfony\Insight\Sdk\Model\Projects;
 
 class Api
 {
-    const ENDPOINT = 'https://insight.sensiolabs.com';
+    const ENDPOINT = 'https://insight.symfony.com';
 
     private $client;
     private $serializer;
@@ -85,7 +85,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'SensioLabs\Insight\Sdk\Model\Projects',
+            'Symfony\Insight\Sdk\Model\Projects',
             'xml'
         );
     }
@@ -101,7 +101,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'SensioLabs\Insight\Sdk\Model\Project',
+            'Symfony\Insight\Sdk\Model\Project',
             'xml'
         );
     }
@@ -117,7 +117,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'SensioLabs\Insight\Sdk\Model\Project',
+            'Symfony\Insight\Sdk\Model\Project',
             'xml'
         );
     }
@@ -133,7 +133,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'SensioLabs\Insight\Sdk\Model\Project',
+            'Symfony\Insight\Sdk\Model\Project',
             'xml'
         );
     }
@@ -149,7 +149,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'SensioLabs\Insight\Sdk\Model\Analyses',
+            'Symfony\Insight\Sdk\Model\Analyses',
             'xml'
         );
     }
@@ -166,7 +166,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'SensioLabs\Insight\Sdk\Model\Analysis',
+            'Symfony\Insight\Sdk\Model\Analysis',
             'xml'
         );
     }
@@ -183,7 +183,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'SensioLabs\Insight\Sdk\Model\Analysis',
+            'Symfony\Insight\Sdk\Model\Analysis',
             'xml'
         );
     }
@@ -206,7 +206,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'SensioLabs\Insight\Sdk\Model\Analysis',
+            'Symfony\Insight\Sdk\Model\Analysis',
             'xml'
         );
     }

--- a/Sdk/Api.php
+++ b/Sdk/Api.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk;
+namespace SymfonyCorp\Insight\Sdk;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 use Guzzle\Common\Collection;
@@ -20,12 +20,12 @@ use Guzzle\Http\Message\RequestInterface;
 use JMS\Serializer\Serializer;
 use JMS\Serializer\SerializerBuilder;
 use Psr\Log\LoggerInterface;
-use Symfony\Insight\Sdk\Exception\ApiClientException;
-use Symfony\Insight\Sdk\Exception\ApiServerException;
-use Symfony\Insight\Sdk\Model\Analyses;
-use Symfony\Insight\Sdk\Model\Analysis;
-use Symfony\Insight\Sdk\Model\Project;
-use Symfony\Insight\Sdk\Model\Projects;
+use SymfonyCorp\Insight\Sdk\Exception\ApiClientException;
+use SymfonyCorp\Insight\Sdk\Exception\ApiServerException;
+use SymfonyCorp\Insight\Sdk\Model\Analyses;
+use SymfonyCorp\Insight\Sdk\Model\Analysis;
+use SymfonyCorp\Insight\Sdk\Model\Project;
+use SymfonyCorp\Insight\Sdk\Model\Projects;
 
 class Api
 {
@@ -85,7 +85,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'Symfony\Insight\Sdk\Model\Projects',
+            'SymfonyCorp\Insight\Sdk\Model\Projects',
             'xml'
         );
     }
@@ -101,7 +101,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'Symfony\Insight\Sdk\Model\Project',
+            'SymfonyCorp\Insight\Sdk\Model\Project',
             'xml'
         );
     }
@@ -117,7 +117,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'Symfony\Insight\Sdk\Model\Project',
+            'SymfonyCorp\Insight\Sdk\Model\Project',
             'xml'
         );
     }
@@ -133,7 +133,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'Symfony\Insight\Sdk\Model\Project',
+            'SymfonyCorp\Insight\Sdk\Model\Project',
             'xml'
         );
     }
@@ -149,7 +149,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'Symfony\Insight\Sdk\Model\Analyses',
+            'SymfonyCorp\Insight\Sdk\Model\Analyses',
             'xml'
         );
     }
@@ -166,7 +166,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'Symfony\Insight\Sdk\Model\Analysis',
+            'SymfonyCorp\Insight\Sdk\Model\Analysis',
             'xml'
         );
     }
@@ -183,7 +183,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'Symfony\Insight\Sdk\Model\Analysis',
+            'SymfonyCorp\Insight\Sdk\Model\Analysis',
             'xml'
         );
     }
@@ -206,7 +206,7 @@ class Api
 
         return $this->serializer->deserialize(
             (string) $this->send($request)->getBody(),
-            'Symfony\Insight\Sdk\Model\Analysis',
+            'SymfonyCorp\Insight\Sdk\Model\Analysis',
             'xml'
         );
     }

--- a/Sdk/Exception/ApiClientException.php
+++ b/Sdk/Exception/ApiClientException.php
@@ -1,17 +1,17 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Exception;
+namespace Symfony\Insight\Sdk\Exception;
 
-use SensioLabs\Insight\Sdk\Model\Error;
+use Symfony\Insight\Sdk\Model\Error;
 
 class ApiClientException extends \LogicException implements ExceptionInterface
 {

--- a/Sdk/Exception/ApiClientException.php
+++ b/Sdk/Exception/ApiClientException.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Exception;
+namespace SymfonyCorp\Insight\Sdk\Exception;
 
-use Symfony\Insight\Sdk\Model\Error;
+use SymfonyCorp\Insight\Sdk\Model\Error;
 
 class ApiClientException extends \LogicException implements ExceptionInterface
 {

--- a/Sdk/Exception/ApiParserException.php
+++ b/Sdk/Exception/ApiParserException.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Exception;
+namespace SymfonyCorp\Insight\Sdk\Exception;
 
 class ApiParserException extends \RuntimeException implements ExceptionInterface
 {

--- a/Sdk/Exception/ApiParserException.php
+++ b/Sdk/Exception/ApiParserException.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Exception;
+namespace Symfony\Insight\Sdk\Exception;
 
 class ApiParserException extends \RuntimeException implements ExceptionInterface
 {

--- a/Sdk/Exception/ApiServerException.php
+++ b/Sdk/Exception/ApiServerException.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Exception;
+namespace SymfonyCorp\Insight\Sdk\Exception;
 
 class ApiServerException extends \RuntimeException implements ExceptionInterface
 {

--- a/Sdk/Exception/ApiServerException.php
+++ b/Sdk/Exception/ApiServerException.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Exception;
+namespace Symfony\Insight\Sdk\Exception;
 
 class ApiServerException extends \RuntimeException implements ExceptionInterface
 {

--- a/Sdk/Exception/ExceptionInterface.php
+++ b/Sdk/Exception/ExceptionInterface.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Exception;
+namespace Symfony\Insight\Sdk\Exception;
 
 interface ExceptionInterface
 {

--- a/Sdk/Exception/ExceptionInterface.php
+++ b/Sdk/Exception/ExceptionInterface.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Exception;
+namespace SymfonyCorp\Insight\Sdk\Exception;
 
 interface ExceptionInterface
 {

--- a/Sdk/Model/Analyses.php
+++ b/Sdk/Model/Analyses.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Model;
+namespace Symfony\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\XmlList;
@@ -17,13 +17,13 @@ use JMS\Serializer\Annotation\XmlList;
 class Analyses
 {
     /**
-     * @Type("array<SensioLabs\Insight\Sdk\Model\Link>")
+     * @Type("array<Symfony\Insight\Sdk\Model\Link>")
      * @XmlList(inline = true, entry = "link")
      */
     private $links = array();
 
     /**
-     * @Type("array<SensioLabs\Insight\Sdk\Model\Analysis>")
+     * @Type("array<Symfony\Insight\Sdk\Model\Analysis>")
      * @XmlList(inline = true, entry = "analysis")
      */
     private $analyses = array();

--- a/Sdk/Model/Analyses.php
+++ b/Sdk/Model/Analyses.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Model;
+namespace SymfonyCorp\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\XmlList;
@@ -17,13 +17,13 @@ use JMS\Serializer\Annotation\XmlList;
 class Analyses
 {
     /**
-     * @Type("array<Symfony\Insight\Sdk\Model\Link>")
+     * @Type("array<SymfonyCorp\Insight\Sdk\Model\Link>")
      * @XmlList(inline = true, entry = "link")
      */
     private $links = array();
 
     /**
-     * @Type("array<Symfony\Insight\Sdk\Model\Analysis>")
+     * @Type("array<SymfonyCorp\Insight\Sdk\Model\Analysis>")
      * @XmlList(inline = true, entry = "analysis")
      */
     private $analyses = array();

--- a/Sdk/Model/Analysis.php
+++ b/Sdk/Model/Analysis.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Model;
+namespace SymfonyCorp\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Type;
@@ -24,7 +24,7 @@ class Analysis
     const STATUS_FINISHED = 'finished';
 
     /**
-     * @Type("array<Symfony\Insight\Sdk\Model\Link>")
+     * @Type("array<SymfonyCorp\Insight\Sdk\Model\Link>")
      * @XmlList(inline = true, entry = "link")
      */
     private $links = array();
@@ -107,7 +107,7 @@ class Analysis
      */
     private $isAltered;
 
-    /** @Type("Symfony\Insight\Sdk\Model\Violations") */
+    /** @Type("SymfonyCorp\Insight\Sdk\Model\Violations") */
     private $violations;
 
     /**

--- a/Sdk/Model/Analysis.php
+++ b/Sdk/Model/Analysis.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Model;
+namespace Symfony\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Type;
@@ -24,7 +24,7 @@ class Analysis
     const STATUS_FINISHED = 'finished';
 
     /**
-     * @Type("array<SensioLabs\Insight\Sdk\Model\Link>")
+     * @Type("array<Symfony\Insight\Sdk\Model\Link>")
      * @XmlList(inline = true, entry = "link")
      */
     private $links = array();
@@ -107,7 +107,7 @@ class Analysis
      */
     private $isAltered;
 
-    /** @Type("SensioLabs\Insight\Sdk\Model\Violations") */
+    /** @Type("Symfony\Insight\Sdk\Model\Violations") */
     private $violations;
 
     /**

--- a/Sdk/Model/Error.php
+++ b/Sdk/Model/Error.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Model;
+namespace SymfonyCorp\Insight\Sdk\Model;
 
 class Error
 {

--- a/Sdk/Model/Error.php
+++ b/Sdk/Model/Error.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Model;
+namespace Symfony\Insight\Sdk\Model;
 
 class Error
 {

--- a/Sdk/Model/Link.php
+++ b/Sdk/Model/Link.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Model;
+namespace SymfonyCorp\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\XmlAttribute;

--- a/Sdk/Model/Link.php
+++ b/Sdk/Model/Link.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Model;
+namespace Symfony\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\XmlAttribute;

--- a/Sdk/Model/Project.php
+++ b/Sdk/Model/Project.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Model;
+namespace Symfony\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Exclude;
@@ -49,7 +49,7 @@ class Project
     );
 
     /**
-     * @Type("array<SensioLabs\Insight\Sdk\Model\Link>")
+     * @Type("array<Symfony\Insight\Sdk\Model\Link>")
      * @XmlList(inline = true, entry = "link")
      */
     private $links = array();
@@ -88,7 +88,7 @@ class Project
     private $reportAvailable;
 
     /**
-     * @Type("SensioLabs\Insight\Sdk\Model\Analysis")
+     * @Type("Symfony\Insight\Sdk\Model\Analysis")
      * @SerializedName("last-analysis")
      */
     private $lastAnalysis;

--- a/Sdk/Model/Project.php
+++ b/Sdk/Model/Project.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Model;
+namespace SymfonyCorp\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\SerializedName;
 use JMS\Serializer\Annotation\Exclude;
@@ -49,7 +49,7 @@ class Project
     );
 
     /**
-     * @Type("array<Symfony\Insight\Sdk\Model\Link>")
+     * @Type("array<SymfonyCorp\Insight\Sdk\Model\Link>")
      * @XmlList(inline = true, entry = "link")
      */
     private $links = array();
@@ -88,7 +88,7 @@ class Project
     private $reportAvailable;
 
     /**
-     * @Type("Symfony\Insight\Sdk\Model\Analysis")
+     * @Type("SymfonyCorp\Insight\Sdk\Model\Analysis")
      * @SerializedName("last-analysis")
      */
     private $lastAnalysis;

--- a/Sdk/Model/Projects.php
+++ b/Sdk/Model/Projects.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Model;
+namespace SymfonyCorp\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\XmlAttribute;
@@ -40,13 +40,13 @@ class Projects
     private $limit;
 
     /**
-     * @Type("array<Symfony\Insight\Sdk\Model\Link>")
+     * @Type("array<SymfonyCorp\Insight\Sdk\Model\Link>")
      * @XmlList(inline = true, entry = "link")
      */
     private $links = array();
 
     /**
-     * @Type("array<Symfony\Insight\Sdk\Model\Project>")
+     * @Type("array<SymfonyCorp\Insight\Sdk\Model\Project>")
      * @XmlList(inline = true, entry = "project")
      */
     private $projects = array();

--- a/Sdk/Model/Projects.php
+++ b/Sdk/Model/Projects.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Model;
+namespace Symfony\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\XmlAttribute;
@@ -40,13 +40,13 @@ class Projects
     private $limit;
 
     /**
-     * @Type("array<SensioLabs\Insight\Sdk\Model\Link>")
+     * @Type("array<Symfony\Insight\Sdk\Model\Link>")
      * @XmlList(inline = true, entry = "link")
      */
     private $links = array();
 
     /**
-     * @Type("array<SensioLabs\Insight\Sdk\Model\Project>")
+     * @Type("array<Symfony\Insight\Sdk\Model\Project>")
      * @XmlList(inline = true, entry = "project")
      */
     private $projects = array();

--- a/Sdk/Model/Violation.php
+++ b/Sdk/Model/Violation.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Model;
+namespace SymfonyCorp\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\XmlAttribute;

--- a/Sdk/Model/Violation.php
+++ b/Sdk/Model/Violation.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Model;
+namespace Symfony\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\XmlAttribute;

--- a/Sdk/Model/Violations.php
+++ b/Sdk/Model/Violations.php
@@ -1,15 +1,15 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Model;
+namespace Symfony\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\XmlList;
@@ -17,7 +17,7 @@ use JMS\Serializer\Annotation\XmlList;
 class Violations implements \Countable, \IteratorAggregate
 {
     /**
-     * @Type("array<SensioLabs\Insight\Sdk\Model\Violation>")
+     * @Type("array<Symfony\Insight\Sdk\Model\Violation>")
      * @XmlList(inline = true, entry = "violation")
      */
     private $violations = array();

--- a/Sdk/Model/Violations.php
+++ b/Sdk/Model/Violations.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Model;
+namespace SymfonyCorp\Insight\Sdk\Model;
 
 use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\XmlList;
@@ -17,7 +17,7 @@ use JMS\Serializer\Annotation\XmlList;
 class Violations implements \Countable, \IteratorAggregate
 {
     /**
-     * @Type("array<Symfony\Insight\Sdk\Model\Violation>")
+     * @Type("array<SymfonyCorp\Insight\Sdk\Model\Violation>")
      * @XmlList(inline = true, entry = "violation")
      */
     private $violations = array();

--- a/Sdk/Parser.php
+++ b/Sdk/Parser.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk;
+namespace SymfonyCorp\Insight\Sdk;
 
-use Symfony\Insight\Sdk\Model\Error;
-use Symfony\Insight\Sdk\Exception\ApiParserException;
+use SymfonyCorp\Insight\Sdk\Model\Error;
+use SymfonyCorp\Insight\Sdk\Exception\ApiParserException;
 
 class Parser
 {

--- a/Sdk/Parser.php
+++ b/Sdk/Parser.php
@@ -1,18 +1,18 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk;
+namespace Symfony\Insight\Sdk;
 
-use SensioLabs\Insight\Sdk\Model\Error;
-use SensioLabs\Insight\Sdk\Exception\ApiParserException;
+use Symfony\Insight\Sdk\Model\Error;
+use Symfony\Insight\Sdk\Exception\ApiParserException;
 
 class Parser
 {

--- a/Sdk/Tests/ApiTest.php
+++ b/Sdk/Tests/ApiTest.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Tests;
+namespace SymfonyCorp\Insight\Sdk\Tests;
 
 use Guzzle\Http\Client;
 use Guzzle\Http\Message\Response;
 use Guzzle\Plugin\Mock\MockPlugin;
 use PHPUnit\Framework\TestCase;
-use Symfony\Insight\Sdk\Api;
-use Symfony\Insight\Sdk\Model\Project;
+use SymfonyCorp\Insight\Sdk\Api;
+use SymfonyCorp\Insight\Sdk\Model\Project;
 
 class ApiTest extends TestCase
 {
@@ -56,14 +56,14 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('projects'));
         $projects = $this->api->getProjects();
 
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Projects', $projects);
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Projects', $projects);
         $this->assertCount(10, $projects->getProjects());
         $this->assertSame(1, $projects->getPage());
         $this->assertSame(12, $projects->getTotal());
         $this->assertSame(10, $projects->getLimit());
 
         $projects = $projects->getProjects();
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Project', reset($projects));
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Project', reset($projects));
     }
 
     public function testGetProjectsWithPage()
@@ -81,14 +81,14 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('projects2'));
         $projects = $this->api->getProjects(2);
 
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Projects', $projects);
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Projects', $projects);
         $this->assertCount(2, $projects->getProjects());
         $this->assertSame(2, $projects->getPage());
         $this->assertSame(12, $projects->getTotal());
         $this->assertSame(10, $projects->getLimit());
 
         $projects = $projects->getProjects();
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Project', reset($projects));
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Project', reset($projects));
     }
 
     public function testGetProject()
@@ -96,7 +96,7 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('project'));
         $project = $this->api->getProject('6718526f-ecdf-497d-bffb-8512f0b402ea');
 
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Project', $project);
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Project', $project);
         $this->assertSame('demo', $project->getName());
         $this->assertNotnull($project->getConfiguration());
         $this->assertSame('git@github.com:lyrixx/demoer.git', $project->getRepositoryUrl());
@@ -104,7 +104,7 @@ class ApiTest extends TestCase
         $this->assertTrue($project->isReportAvailable());
         $this->assertSame(1, $project->getType());
 
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Analysis', $project->getLastAnalysis());
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Analysis', $project->getLastAnalysis());
     }
 
     public function testCreateProjectOk()
@@ -114,7 +114,7 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('project'));
         $project = $this->api->createProject($project);
 
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Project', $project);
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Project', $project);
     }
 
     public function testCreateProjectNOk()
@@ -126,9 +126,9 @@ class ApiTest extends TestCase
             $project = $this->api->createProject($project);
             $this->fail('Something should go wrong');
         } catch (\Exception $e) {
-            $this->assertInstanceOf('Symfony\Insight\Sdk\Exception\ApiClientException', $e);
+            $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Exception\ApiClientException', $e);
             $this->assertSame('Your request in not valid (status code: "400", reason phrase: "Bad Request").See $error attached to the exception', $e->getMessage());
-            $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Error', $e->getError());
+            $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Error', $e->getError());
         }
     }
 
@@ -139,7 +139,7 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('project'));
         $project = $this->api->updateProject($project);
 
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Project', $project);
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Project', $project);
     }
 
     public function testupdateProjectNOk()
@@ -151,9 +151,9 @@ class ApiTest extends TestCase
             $project = $this->api->updateProject($project);
             $this->fail('Something should go wrong');
         } catch (\Exception $e) {
-            $this->assertInstanceOf('Symfony\Insight\Sdk\Exception\ApiClientException', $e);
+            $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Exception\ApiClientException', $e);
             $this->assertSame('Your request in not valid (status code: "400", reason phrase: "Bad Request").See $error attached to the exception', $e->getMessage());
-            $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Error', $e->getError());
+            $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Error', $e->getError());
         }
     }
 
@@ -162,11 +162,11 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('analyses'));
         $analyses = $this->api->getAnalyses('6718526f-ecdf-497d-bffb-8512f0b402ea');
 
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Analyses', $analyses);
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Analyses', $analyses);
         $this->assertCount(2, $analyses->getAnalyses());
 
         $analyses = $analyses->getAnalyses();
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Analysis', reset($analyses));
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Analysis', reset($analyses));
     }
 
     public function testGetAnalysis()
@@ -174,7 +174,7 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('analysis'));
         $analysis = $this->api->getAnalysis('6718526f-ecdf-497d-bffb-8512f0b402ea', 1);
 
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Analysis', $analysis);
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Analysis', $analysis);
         $this->assertSame(49, $analysis->getNumber());
         $this->assertSame('error', $analysis->getGrade());
         $this->assertSame('bronze', $analysis->getNextGrade());
@@ -188,12 +188,12 @@ class ApiTest extends TestCase
         $this->assertNull($analysis->getFailureMessage());
         $this->assertNull($analysis->getFailureCode());
         $this->assertFalse($analysis->isAltered());
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Violations', $analysis->getViolations());
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Violations', $analysis->getViolations());
         $this->assertCount(250, $analysis->getViolations()->getViolations());
 
         $violations = $analysis->getViolations()->getViolations();
         $firstViolation = reset($violations);
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Violation', $firstViolation);
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Violation', $firstViolation);
 
         $this->assertSame(7, $firstViolation->getLine());
         $this->assertSame('critical', $firstViolation->getSeverity());
@@ -206,7 +206,7 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('status'));
         $analysis = $this->api->getAnalysisStatus('6718526f-ecdf-497d-bffb-8512f0b402ea', 1);
 
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Analysis', $analysis);
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Analysis', $analysis);
         $this->assertSame(49, $analysis->getNumber());
         $this->assertSame('2013-06-25T19:37:20+02:00', $analysis->getBeginAt()->format('c'));
         $this->assertSame('2013-06-25T19:37:53+02:00', $analysis->getEndAt()->format('c'));
@@ -218,7 +218,7 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('analysis'));
         $analysis = $this->api->analyze('6718526f-ecdf-497d-bffb-8512f0b402ea', 'SHA');
 
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Analysis', $analysis);
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Analysis', $analysis);
     }
 
     public function tearDown()

--- a/Sdk/Tests/ApiTest.php
+++ b/Sdk/Tests/ApiTest.php
@@ -1,22 +1,22 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Tests;
+namespace Symfony\Insight\Sdk\Tests;
 
 use Guzzle\Http\Client;
 use Guzzle\Http\Message\Response;
 use Guzzle\Plugin\Mock\MockPlugin;
 use PHPUnit\Framework\TestCase;
-use SensioLabs\Insight\Sdk\Api;
-use SensioLabs\Insight\Sdk\Model\Project;
+use Symfony\Insight\Sdk\Api;
+use Symfony\Insight\Sdk\Model\Project;
 
 class ApiTest extends TestCase
 {
@@ -56,14 +56,14 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('projects'));
         $projects = $this->api->getProjects();
 
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Projects', $projects);
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Projects', $projects);
         $this->assertCount(10, $projects->getProjects());
         $this->assertSame(1, $projects->getPage());
         $this->assertSame(12, $projects->getTotal());
         $this->assertSame(10, $projects->getLimit());
 
         $projects = $projects->getProjects();
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Project', reset($projects));
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Project', reset($projects));
     }
 
     public function testGetProjectsWithPage()
@@ -81,14 +81,14 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('projects2'));
         $projects = $this->api->getProjects(2);
 
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Projects', $projects);
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Projects', $projects);
         $this->assertCount(2, $projects->getProjects());
         $this->assertSame(2, $projects->getPage());
         $this->assertSame(12, $projects->getTotal());
         $this->assertSame(10, $projects->getLimit());
 
         $projects = $projects->getProjects();
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Project', reset($projects));
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Project', reset($projects));
     }
 
     public function testGetProject()
@@ -96,7 +96,7 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('project'));
         $project = $this->api->getProject('6718526f-ecdf-497d-bffb-8512f0b402ea');
 
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Project', $project);
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Project', $project);
         $this->assertSame('demo', $project->getName());
         $this->assertNotnull($project->getConfiguration());
         $this->assertSame('git@github.com:lyrixx/demoer.git', $project->getRepositoryUrl());
@@ -104,7 +104,7 @@ class ApiTest extends TestCase
         $this->assertTrue($project->isReportAvailable());
         $this->assertSame(1, $project->getType());
 
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Analysis', $project->getLastAnalysis());
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Analysis', $project->getLastAnalysis());
     }
 
     public function testCreateProjectOk()
@@ -114,7 +114,7 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('project'));
         $project = $this->api->createProject($project);
 
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Project', $project);
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Project', $project);
     }
 
     public function testCreateProjectNOk()
@@ -126,9 +126,9 @@ class ApiTest extends TestCase
             $project = $this->api->createProject($project);
             $this->fail('Something should go wrong');
         } catch (\Exception $e) {
-            $this->assertInstanceOf('SensioLabs\Insight\Sdk\Exception\ApiClientException', $e);
+            $this->assertInstanceOf('Symfony\Insight\Sdk\Exception\ApiClientException', $e);
             $this->assertSame('Your request in not valid (status code: "400", reason phrase: "Bad Request").See $error attached to the exception', $e->getMessage());
-            $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Error', $e->getError());
+            $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Error', $e->getError());
         }
     }
 
@@ -139,7 +139,7 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('project'));
         $project = $this->api->updateProject($project);
 
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Project', $project);
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Project', $project);
     }
 
     public function testupdateProjectNOk()
@@ -151,9 +151,9 @@ class ApiTest extends TestCase
             $project = $this->api->updateProject($project);
             $this->fail('Something should go wrong');
         } catch (\Exception $e) {
-            $this->assertInstanceOf('SensioLabs\Insight\Sdk\Exception\ApiClientException', $e);
+            $this->assertInstanceOf('Symfony\Insight\Sdk\Exception\ApiClientException', $e);
             $this->assertSame('Your request in not valid (status code: "400", reason phrase: "Bad Request").See $error attached to the exception', $e->getMessage());
-            $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Error', $e->getError());
+            $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Error', $e->getError());
         }
     }
 
@@ -162,11 +162,11 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('analyses'));
         $analyses = $this->api->getAnalyses('6718526f-ecdf-497d-bffb-8512f0b402ea');
 
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Analyses', $analyses);
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Analyses', $analyses);
         $this->assertCount(2, $analyses->getAnalyses());
 
         $analyses = $analyses->getAnalyses();
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Analysis', reset($analyses));
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Analysis', reset($analyses));
     }
 
     public function testGetAnalysis()
@@ -174,7 +174,7 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('analysis'));
         $analysis = $this->api->getAnalysis('6718526f-ecdf-497d-bffb-8512f0b402ea', 1);
 
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Analysis', $analysis);
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Analysis', $analysis);
         $this->assertSame(49, $analysis->getNumber());
         $this->assertSame('error', $analysis->getGrade());
         $this->assertSame('bronze', $analysis->getNextGrade());
@@ -188,12 +188,12 @@ class ApiTest extends TestCase
         $this->assertNull($analysis->getFailureMessage());
         $this->assertNull($analysis->getFailureCode());
         $this->assertFalse($analysis->isAltered());
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Violations', $analysis->getViolations());
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Violations', $analysis->getViolations());
         $this->assertCount(250, $analysis->getViolations()->getViolations());
 
         $violations = $analysis->getViolations()->getViolations();
         $firstViolation = reset($violations);
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Violation', $firstViolation);
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Violation', $firstViolation);
 
         $this->assertSame(7, $firstViolation->getLine());
         $this->assertSame('critical', $firstViolation->getSeverity());
@@ -206,7 +206,7 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('status'));
         $analysis = $this->api->getAnalysisStatus('6718526f-ecdf-497d-bffb-8512f0b402ea', 1);
 
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Analysis', $analysis);
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Analysis', $analysis);
         $this->assertSame(49, $analysis->getNumber());
         $this->assertSame('2013-06-25T19:37:20+02:00', $analysis->getBeginAt()->format('c'));
         $this->assertSame('2013-06-25T19:37:53+02:00', $analysis->getEndAt()->format('c'));
@@ -218,7 +218,7 @@ class ApiTest extends TestCase
         $this->pluginMockResponse->addResponse($this->createResponse('analysis'));
         $analysis = $this->api->analyze('6718526f-ecdf-497d-bffb-8512f0b402ea', 'SHA');
 
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Analysis', $analysis);
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Analysis', $analysis);
     }
 
     public function tearDown()

--- a/Sdk/Tests/Model/ViolationsTest.php
+++ b/Sdk/Tests/Model/ViolationsTest.php
@@ -1,18 +1,18 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Tests\Sdk\Model;
+namespace Symfony\Insight\Tests\Sdk\Model;
 
 use PHPUnit\Framework\TestCase;
-use SensioLabs\Insight\Sdk\Model\Violations;
+use Symfony\Insight\Sdk\Model\Violations;
 
 class ViolationsTest extends TestCase
 {

--- a/Sdk/Tests/Model/ViolationsTest.php
+++ b/Sdk/Tests/Model/ViolationsTest.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Tests\Sdk\Model;
+namespace SymfonyCorp\Insight\Tests\Sdk\Model;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Insight\Sdk\Model\Violations;
+use SymfonyCorp\Insight\Sdk\Model\Violations;
 
 class ViolationsTest extends TestCase
 {

--- a/Sdk/Tests/ParserTest.php
+++ b/Sdk/Tests/ParserTest.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Insight\Sdk\Tests;
+namespace SymfonyCorp\Insight\Sdk\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Insight\Sdk\Parser;
+use SymfonyCorp\Insight\Sdk\Parser;
 
 class ParserTest extends TestCase
 {
@@ -36,7 +36,7 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Insight\Sdk\Exception\ApiParserException
+     * @expectedException \SymfonyCorp\Insight\Sdk\Exception\ApiParserException
      * @expectedExceptionMessage Could not transform this xml to a \DOMDocument instance.
      * @dataProvider getParseErrorsFailedIfDocumentIfInvalidTests
      */
@@ -61,7 +61,7 @@ class ParserTest extends TestCase
             ),
         );
 
-        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Error', $error);
+        $this->assertInstanceOf('SymfonyCorp\Insight\Sdk\Model\Error', $error);
         $this->assertSame($expectedFields, $error->getEntityBodyParameters());
     }
 

--- a/Sdk/Tests/ParserTest.php
+++ b/Sdk/Tests/ParserTest.php
@@ -1,18 +1,18 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
 
-namespace SensioLabs\Insight\Sdk\Tests;
+namespace Symfony\Insight\Sdk\Tests;
 
 use PHPUnit\Framework\TestCase;
-use SensioLabs\Insight\Sdk\Parser;
+use Symfony\Insight\Sdk\Parser;
 
 class ParserTest extends TestCase
 {
@@ -36,7 +36,7 @@ class ParserTest extends TestCase
     }
 
     /**
-     * @expectedException \SensioLabs\Insight\Sdk\Exception\ApiParserException
+     * @expectedException \Symfony\Insight\Sdk\Exception\ApiParserException
      * @expectedExceptionMessage Could not transform this xml to a \DOMDocument instance.
      * @dataProvider getParseErrorsFailedIfDocumentIfInvalidTests
      */
@@ -61,7 +61,7 @@ class ParserTest extends TestCase
             ),
         );
 
-        $this->assertInstanceOf('SensioLabs\Insight\Sdk\Model\Error', $error);
+        $this->assertInstanceOf('Symfony\Insight\Sdk\Model\Error', $error);
         $this->assertSame($expectedFields, $error->getEntityBodyParameters());
     }
 

--- a/Sdk/Tests/fixtures/projects.xml
+++ b/Sdk/Tests/fixtures/projects.xml
@@ -40,7 +40,7 @@
       </grades>
       <id>47</id>
       <failed>true</failed>
-      <failure-message><![CDATA[The private SensioLabs repository has not been created yet.]]></failure-message>
+      <failure-message><![CDATA[The private Symfony repository has not been created yet.]]></failure-message>
       <begin-at><![CDATA[2013-06-25T11:40:45+0200]]></begin-at>
       <altered>false</altered>
       <status><![CDATA[finished]]></status>

--- a/bin/insight
+++ b/bin/insight
@@ -2,9 +2,9 @@
 <?php
 
 /*
- * This file is part of the SensioLabsInsight package.
+ * This file is part of the SymfonyInsight package.
  *
- * (c) SensioLabs <contact@sensiolabs.com>
+ * (c) Symfony <support@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -17,7 +17,7 @@ if (file_exists($a = __DIR__.'/../../../autoload.php')) {
     require_once __DIR__.'/../vendor/autoload.php';
 }
 
-use SensioLabs\Insight\Cli\Application;
+use Symfony\Insight\Cli\Application;
 
 $application = new Application();
 

--- a/bin/insight
+++ b/bin/insight
@@ -17,8 +17,7 @@ if (file_exists($a = __DIR__.'/../../../autoload.php')) {
     require_once __DIR__.'/../vendor/autoload.php';
 }
 
-use Symfony\Insight\Cli\Application;
+use SymfonyCorp\Insight\Cli\Application;
 
 $application = new Application();
-
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Symfony\\Insight\\": ""
+            "SymfonyCorp\\Insight\\": ""
         }
     },
     "bin": ["bin/insight"],
     "extra": {
         "branch-alias": {
-            "dev-master": "1.5.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     ],
     "require": {
+        "php": ">7.1",
         "guzzle/http": "~3.7",
         "jms/serializer": "0.12.*",
         "psr/log": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
-    "name": "sensiolabs/insight",
-    "description": "SensioLabs Insight SDK",
+    "name": "symfonycorp/insight",
+    "description": "SymfonyInsight SDK",
     "license": "MIT",
     "authors": [
         {
             "name": "Grégoire Pineau",
             "email": "lyrixx@lyrixx.info"
+        },
+        {
+            "name": "Titouan Galopin",
+            "email": "titouan.galopin@symfony.com"
         }
     ],
     "require": {
@@ -25,7 +29,7 @@
     },
     "autoload": {
         "psr-4": {
-            "SensioLabs\\Insight\\": ""
+            "Symfony\\Insight\\": ""
         }
     },
     "bin": ["bin/insight"],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,7 @@
     bootstrap                   = "vendor/autoload.php" >
 
     <testsuites>
-        <testsuite name="SensioLabs Insight Sdk">
+        <testsuite name="SymfonyInsight Sdk">
             <directory>Sdk/Tests</directory>
         </testsuite>
     </testsuites>


### PR DESCRIPTION
Prepares version 2.0 of the SDK, including:

- migration to the name SymfonyInsight (https://blog.insight.symfony.com/2018/10/01/sensiolabsinsight-becomes-symfonyinsight.html)
- migration to CircleCI
- drop support for PHP 5 and PHP 7.0
- add PHP-CS configuration