### PR TITLE
Upgrade to Box3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ jobs:
       php: 5.3
       dist: precise
       install:
-        - composer install --no-dev -o
-        - curl -LSs https://box-project.github.io/box2/installer.php | php
+        - composer install --no-dev
+        - wget https://github.com/humbug/box/releases/download/3.7.0/box.phar
       script:
         - mkdir -p build/
-        - php box.phar build
+        - php box.phar compile
       deploy:
         provider: s3
         access_key_id: $AWS_ACCESS_KEY_ID

--- a/bin/insight
+++ b/bin/insight
@@ -10,15 +10,21 @@
  * file that was distributed with this source code.
  */
 
-// installed via composer?
-if (file_exists($a = __DIR__.'/../../../autoload.php')) {
-    require_once $a;
-} else {
-    require_once __DIR__.'/../vendor/autoload.php';
-}
-
 use SensioLabs\Insight\Cli\Application;
 
-$application = new Application();
+if (false === in_array(PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
+    echo PHP_EOL.'Insight may only be invoked from a command line, got "'.PHP_SAPI.'"'.PHP_EOL;
+    exit(1);
+}
 
-$application->run();
+if (file_exists($autoload = __DIR__.'/../../../autoload.php')) {
+    // Is installed via Composer
+    include_once $autoload;
+} elseif (file_exists($autoload = __DIR__.'/../vendor/autoload.php')) {
+    // Is installed locally
+    include_once $autoload;
+} else {
+    throw new RuntimeException('Unable to find the Composer autoloader.');
+}
+
+(new Application())->run();

--- a/box.json
+++ b/box.json
@@ -1,8 +1,0 @@
-{
-    "chmod": "0755",
-    "main": "bin/insight",
-    "output": "build/insight.phar",
-    "stub": true,
-    "directories": ["."],
-    "git-commit": "git-commit"
-}

--- a/box.json.dist
+++ b/box.json.dist
@@ -1,0 +1,4 @@
+{
+    "output": "build/insight.phar",
+    "git-commit": "git-commit"
+}


### PR DESCRIPTION
Please double check the resulting PHAR. Indeed I migrated the Box configuration to leverage the newly introduced features in Box3, namely figuring out which files to include in the PHAR. The small diff is as follows:

```
Archive: box3-insight.phar
Compression: None
Metadata: None
Contents: 476 files (2.12MB)

Archive: box2-insight.phar
Compression: None
Metadata: None
Contents: 1071 files (3.32MB)
```

The more extensive diff:

<details>

<summary>Extensive diff</summary>

```
 // Comparing the two archives contents...                                                                              

--- Files present in "box2-insight.phar" but not in "box3-insight.phar"
+++ Files present in "box3-insight.phar" but not in "box2-insight.phar"

- box.json [NONE] - 163.00B
- box.json.dist [NONE] - 71.00B
- composer.json [NONE] - 887.00B
- composer.lock [NONE] - 40.97KB
- phpunit.xml.dist [NONE] - 930.00B
- README.md [NONE] - 5.53KB
- Sdk/Tests/ApiTest.php [NONE] - 9.11KB
- Sdk/Tests/fixtures/analyses.xml [NONE] - 4.43KB
- Sdk/Tests/fixtures/analysis.xml [NONE] - 89.97KB
- Sdk/Tests/fixtures/errors.xml [NONE] - 492.00B
- Sdk/Tests/fixtures/project.xml [NONE] - 95.63KB
- Sdk/Tests/fixtures/projects.xml [NONE] - 14.73KB
- Sdk/Tests/fixtures/projects2.xml [NONE] - 4.67KB
- Sdk/Tests/fixtures/status.xml [NONE] - 1.22KB
- Sdk/Tests/Model/ViolationsTest.php [NONE] - 1.27KB
- Sdk/Tests/ParserTest.php [NONE] - 1.75KB
- vendor/composer/installed.json [NONE] - 30.78KB
- vendor/doctrine/annotations/CHANGELOG.md [NONE] - 8.94KB
- vendor/doctrine/annotations/composer.json [NONE] - 1.11KB
- vendor/doctrine/annotations/docs/en/annotations.rst [NONE] - 10.06KB
- vendor/doctrine/annotations/docs/en/custom.rst [NONE] - 7.45KB
- vendor/doctrine/annotations/docs/en/index.rst [NONE] - 2.34KB
- vendor/doctrine/annotations/docs/en/sidebar.rst [NONE] - 65.00B
- vendor/doctrine/annotations/phpstan.neon [NONE] - 1.15KB
- vendor/doctrine/annotations/README.md [NONE] - 1.02KB
- vendor/doctrine/lexer/composer.json [NONE] - 738.00B
- vendor/doctrine/lexer/README.md [NONE] - 171.00B
- vendor/guzzle/common/Guzzle/Common/composer.json [NONE] - 503.00B
- vendor/guzzle/http/Guzzle/Http/composer.json [NONE] - 808.00B
- vendor/guzzle/parser/Guzzle/Parser/composer.json [NONE] - 471.00B
- vendor/guzzle/stream/Guzzle/Stream/composer.json [NONE] - 766.00B
- vendor/jms/metadata/CHANGELOG.md [NONE] - 1.13KB
- vendor/jms/metadata/composer.json [NONE] - 743.00B
- vendor/jms/metadata/composer.lock [NONE] - 8.04KB
- vendor/jms/metadata/phpunit.xml.dist [NONE] - 679.00B
- vendor/jms/metadata/README.rst [NONE] - 1.23KB
- vendor/jms/metadata/tests/bootstrap.php [NONE] - 979.00B
- vendor/jms/metadata/tests/Metadata/Tests/Cache/DoctrineCacheAdapterTest.php [NONE] - 1.01KB
- vendor/jms/metadata/tests/Metadata/Tests/Cache/FileCacheTest.php [NONE] - 734.00B
- vendor/jms/metadata/tests/Metadata/Tests/Cache/PsrCacheAdapterTest.php [NONE] - 1.01KB
- vendor/jms/metadata/tests/Metadata/Tests/ClassMetadataTest.php [NONE] - 1.11KB
- vendor/jms/metadata/tests/Metadata/Tests/Driver/AbstractFileDriverTest.php [NONE] - 2.75KB
- vendor/jms/metadata/tests/Metadata/Tests/Driver/DriverChainTest.php [NONE] - 2.20KB
- vendor/jms/metadata/tests/Metadata/Tests/Driver/FileLocatorTest.php [NONE] - 2.67KB
- vendor/jms/metadata/tests/Metadata/Tests/Driver/Fixture/A/A.php [NONE] - 62.00B
- vendor/jms/metadata/tests/Metadata/Tests/Driver/Fixture/A/A.xml [NONE] - 0.00B
- vendor/jms/metadata/tests/Metadata/Tests/Driver/Fixture/B/B.php [NONE] - 62.00B
- vendor/jms/metadata/tests/Metadata/Tests/Driver/Fixture/B/B.yml [NONE] - 0.00B
- vendor/jms/metadata/tests/Metadata/Tests/Driver/Fixture/C/SubDir/C.php [NONE] - 69.00B
- vendor/jms/metadata/tests/Metadata/Tests/Driver/Fixture/C/SubDir.C.yml [NONE] - 0.00B
- vendor/jms/metadata/tests/Metadata/Tests/Driver/Fixture/D/D.php [NONE] - 19.00B
- vendor/jms/metadata/tests/Metadata/Tests/Driver/Fixture/D/D.yml [NONE] - 0.00B
- vendor/jms/metadata/tests/Metadata/Tests/Driver/Fixture/T/T.php [NONE] - 62.00B
- vendor/jms/metadata/tests/Metadata/Tests/Driver/Fixture/T/T.xml [NONE] - 0.00B
- vendor/jms/metadata/tests/Metadata/Tests/Fixtures/ComplexHierarchy/BaseClass.php [NONE] - 128.00B
- vendor/jms/metadata/tests/Metadata/Tests/Fixtures/ComplexHierarchy/InterfaceA.php [NONE] - 85.00B
- vendor/jms/metadata/tests/Metadata/Tests/Fixtures/ComplexHierarchy/InterfaceB.php [NONE] - 85.00B
- vendor/jms/metadata/tests/Metadata/Tests/Fixtures/ComplexHierarchy/SubClassA.php [NONE] - 149.00B
- vendor/jms/metadata/tests/Metadata/Tests/Fixtures/ComplexHierarchy/SubClassB.php [NONE] - 115.00B
- vendor/jms/metadata/tests/Metadata/Tests/Fixtures/TestObject.php [NONE] - 225.00B
- vendor/jms/metadata/tests/Metadata/Tests/Fixtures/TestParent.php [NONE] - 82.00B
- vendor/jms/metadata/tests/Metadata/Tests/MergeableClassMetadataTest.php [NONE] - 1.37KB
- vendor/jms/metadata/tests/Metadata/Tests/MetadataFactoryTest.php [NONE] - 10.81KB
- vendor/jms/metadata/tests/Metadata/Tests/MethodMetadataTest.php [NONE] - 1.17KB
- vendor/jms/metadata/tests/Metadata/Tests/PropertyMetadataTest.php [NONE] - 1.19KB
- vendor/jms/parser-lib/composer.json [NONE] - 385.00B
- vendor/jms/parser-lib/composer.lock [NONE] - 1.61KB
- vendor/jms/parser-lib/doc/index.rst [NONE] - 3.36KB
- vendor/jms/parser-lib/doc/LICENSE [NONE] - 15.76KB
- vendor/jms/parser-lib/phpunit.xml.dist [NONE] - 668.00B
- vendor/jms/parser-lib/README.md [NONE] - 110.00B
- vendor/jms/parser-lib/tests/bootstrap.php [NONE] - 225.00B
- vendor/jms/parser-lib/tests/JMS/Parser/Tests/AbstractLexerTest.php [NONE] - 3.69KB
- vendor/jms/parser-lib/tests/JMS/Parser/Tests/AbstractParserTest.php [NONE] - 2.89KB
- vendor/jms/serializer/CHANGELOG.md [NONE] - 562.00B
- vendor/jms/serializer/composer.json [NONE] - 1.27KB
- vendor/jms/serializer/composer.lock [NONE] - 41.14KB
- vendor/jms/serializer/doc/configuration.rst [NONE] - 3.30KB
- vendor/jms/serializer/doc/cookbook/exclusion_strategies.rst [NONE] - 3.13KB
- vendor/jms/serializer/doc/cookbook.rst [NONE] - 65.00B
- vendor/jms/serializer/doc/event_system.rst [NONE] - 2.62KB
- vendor/jms/serializer/doc/handlers.rst [NONE] - 1.93KB
- vendor/jms/serializer/doc/index.rst [NONE] - 1.75KB
- vendor/jms/serializer/doc/LICENSE [NONE] - 15.76KB
- vendor/jms/serializer/doc/reference/annotations.rst [NONE] - 13.68KB
- vendor/jms/serializer/doc/reference/xml_reference.rst [NONE] - 2.05KB
- vendor/jms/serializer/doc/reference/yml_reference.rst [NONE] - 1.74KB
- vendor/jms/serializer/doc/reference.rst [NONE] - 86.00B
- vendor/jms/serializer/doc/usage.rst [NONE] - 1,017.00B
- vendor/jms/serializer/phpunit.xml.dist [NONE] - 683.00B
- vendor/jms/serializer/README.md [NONE] - 101.00B
- vendor/jms/serializer/tests/bootstrap.php [NONE] - 1.06KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Exclusion/DisjunctExclusionStrategyTest.php [NONE] - 5.79KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/AccessorOrderChild.php [NONE] - 887.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/AccessorOrderParent.php [NONE] - 835.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/AllExcludedObject.php [NONE] - 968.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Article.php [NONE] - 2.39KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Author.php [NONE] - 1.00KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/AuthorList.php [NONE] - 2.05KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/AuthorReadOnly.php [NONE] - 1.35KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/BlogPost.php [NONE] - 2.70KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/CircularReferenceChild.php [NONE] - 1.26KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/CircularReferenceParent.php [NONE] - 1.95KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Comment.php [NONE] - 1.07KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/CurrencyAwareOrder.php [NONE] - 1.01KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/CurrencyAwarePrice.php [NONE] - 1.11KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/CustomDeserializationObject.php [NONE] - 910.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Discriminator/Car.php [NONE] - 722.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Discriminator/Moped.php [NONE] - 724.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Discriminator/Vehicle.php [NONE] - 1.08KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Doctrine/Author.php [NONE] - 1.15KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Doctrine/BlogPost.php [NONE] - 2.57KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Doctrine/Comment.php [NONE] - 1.36KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/GetSetObject.php [NONE] - 1.37KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/GroupsObject.php [NONE] - 1.25KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/IndexedCommentsBlogPost.php [NONE] - 2.02KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/InitializedObjectConstructor.php [NONE] - 1.43KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/InlineChild.php [NONE] - 905.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/InlineParent.php [NONE] - 1.14KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Input.php [NONE] - 1.06KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/InvalidGroupsObject.php [NONE] - 869.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/InvalidUsageOfXmlValue.php [NONE] - 845.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Log.php [NONE] - 1.59KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Node.php [NONE] - 865.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/ObjectWithEmptyHash.php [NONE] - 848.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/ObjectWithLifecycleCallbacks.php [NONE] - 1.71KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/ObjectWithNullProperty.php [NONE] - 816.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/ObjectWithVersionedVirtualProperties.php [NONE] - 1.46KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/ObjectWithVirtualProperties.php [NONE] - 1.49KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/ObjectWithVirtualPropertiesAndExcludeAll.php [NONE] - 973.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/ObjectWithVirtualXmlProperties.php [NONE] - 2.38KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/ObjectWithXmlKeyValuePairs.php [NONE] - 1.17KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Order.php [NONE] - 982.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Person.php [NONE] - 1.01KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/PersonCollection.php [NONE] - 1.19KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/PersonLocation.php [NONE] - 970.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/Price.php [NONE] - 992.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/SimpleObject.php [NONE] - 1.20KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/SimpleObjectProxy.php [NONE] - 1.09KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Fixtures/VersionedObject.php [NONE] - 1.07KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/ClassMetadataTest.php [NONE] - 2.37KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/AnnotationDriverTest.php [NONE] - 951.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/BaseDriverTest.php [NONE] - 6.00KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/DoctrineDriverTest.php [NONE] - 4.34KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/php/AuthorReadOnly.php [NONE] - 148.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/php/BlogPost.php [NONE] - 1.48KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.Car.php [NONE] - 197.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.Moped.php [NONE] - 199.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/php/Discriminator.Vehicle.php [NONE] - 532.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/php/ObjectWithVirtualProperties.php [NONE] - 966.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/php/ObjectWithVirtualPropertiesAndExcludeAll.php [NONE] - 410.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/php/ObjectWithXmlKeyValuePairs.php [NONE] - 370.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/php/Price.php [NONE] - 373.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/PhpDriverTest.php [NONE] - 987.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/AuthorReadOnly.xml [NONE] - 343.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/BlogPost.xml [NONE] - 743.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/case/BlogPost.xml [NONE] - 247.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.Car.xml [NONE] - 145.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.Moped.xml [NONE] - 147.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Discriminator.Vehicle.xml [NONE] - 453.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/exclude_all/BlogPost.xml [NONE] - 247.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/exclude_none/BlogPost.xml [NONE] - 249.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/GetSetObject.xml [NONE] - 354.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/invalid.xml [NONE] - 34.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/ObjectWithVirtualProperties.xml [NONE] - 424.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/ObjectWithVirtualPropertiesAndExcludeAll.xml [NONE] - 245.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/ObjectWithXmlKeyValuePairs.xml [NONE] - 230.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/xml/Price.xml [NONE] - 198.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/XmlDriverTest.php [NONE] - 3.26KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/YamlDriverTest.php [NONE] - 2.82KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/accessor/BlogPost.yml [NONE] - 198.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/AuthorReadOnly.yml [NONE] - 299.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/BlogPost.yml [NONE] - 692.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/case/BlogPost.yml [NONE] - 176.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.Car.yml [NONE] - 52.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.Moped.yml [NONE] - 54.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Discriminator.Vehicle.yml [NONE] - 298.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/exclude_all/BlogPost.yml [NONE] - 176.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/exclude_none/BlogPost.yml [NONE] - 178.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/ObjectWithVirtualProperties.yml [NONE] - 299.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/ObjectWithVirtualPropertiesAndExcludeAll.yml [NONE] - 148.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/ObjectWithXmlKeyValuePairs.yml [NONE] - 151.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Metadata/Driver/yml/Price.yml [NONE] - 120.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/PerformanceTest.php [NONE] - 4.15KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/BaseSerializationTest.php [NONE] - 29.59KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/ContextTest.php [NONE] - 6.73KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/DateIntervalFormatTest.php [NONE] - 1.30KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/EventDispatcher/EventDispatcherTest.php [NONE] - 4.75KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/EventDispatcher/Subscriber/DoctrineProxySubscriberTest.php [NONE] - 2.18KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/EventDispatcher/Subscriber/SymfonyValidatorSubscriberTest.php [NONE] - 4.06KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/GraphNavigatorTest.php [NONE] - 7.29KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/JsonSerializationTest.php [NONE] - 9.18KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/Naming/IdenticalPropertyNamingStrategyTest.php [NONE] - 1.42KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/TypeParserTest.php [NONE] - 3.11KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/accessor_order_child.xml [NONE] - 150.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/accessor_order_parent.xml [NONE] - 104.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/array_booleans.xml [NONE] - 103.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/array_floats.xml [NONE] - 121.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/array_integers.xml [NONE] - 115.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/array_key_values.xml [NONE] - 483.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/array_mixed.xml [NONE] - 347.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/array_objects.xml [NONE] - 314.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/array_strings.xml [NONE] - 124.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/article.xml [NONE] - 67.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/blog_post.xml [NONE] - 586.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/blog_post_unauthored.xml [NONE] - 201.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/boolean_false.xml [NONE] - 62.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/boolean_true.xml [NONE] - 61.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/car.xml [NONE] - 102.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/car_without_type.xml [NONE] - 71.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/circular_reference.xml [NONE] - 388.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/constraint_violation.xml [NONE] - 138.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/constraint_violation_list.xml [NONE] - 276.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/currency_aware_price.xml [NONE] - 74.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/custom_accessor.xml [NONE] - 393.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/date_interval.xml [NONE] - 74.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/date_time.xml [NONE] - 93.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/float.xml [NONE] - 62.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/float_trailing_zero.xml [NONE] - 58.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/form_errors.xml [NONE] - 153.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/groups_all.xml [NONE] - 186.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/groups_default.xml [NONE] - 119.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/groups_foo.xml [NONE] - 125.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/groups_foobar.xml [NONE] - 154.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/hash_empty.xml [NONE] - 68.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/inline.xml [NONE] - 150.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/input.xml [NONE] - 92.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/integer.xml [NONE] - 58.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/lifecycle_callbacks.xml [NONE] - 93.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/log.xml [NONE] - 663.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/mixed_access_types.xml [NONE] - 153.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/nested_form_errors.xml [NONE] - 256.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/null.xml [NONE] - 64.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/nullable.xml [NONE] - 143.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/object_when_null.xml [NONE] - 89.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/object_when_null_and_serialized.xml [NONE] - 116.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/order.xml [NONE] - 77.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/order_with_currency_aware_price.xml [NONE] - 91.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/orm_proxy.xml [NONE] - 165.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/person_collection.xml [NONE] - 187.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/person_location.xml [NONE] - 183.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/price.xml [NONE] - 56.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/readonly.xml [NONE] - 124.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/simple_object.xml [NONE] - 159.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/simple_object_nullable.xml [NONE] - 193.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/string.xml [NONE] - 72.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/virtual_attributes.xml [NONE] - 59.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/virtual_properties.xml [NONE] - 247.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/virtual_properties_all.xml [NONE] - 90.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/virtual_properties_high.xml [NONE] - 75.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/virtual_properties_list.xml [NONE] - 116.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/virtual_properties_low.xml [NONE] - 73.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/virtual_properties_map.xml [NONE] - 173.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/xml/virtual_values.xml [NONE] - 78.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/XmlSerializationTest.php [NONE] - 6.32KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/YamlSerializationTest.php [NONE] - 1.70KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/accessor_order_child.yml [NONE] - 20.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/accessor_order_parent.yml [NONE] - 10.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/array_booleans.yml [NONE] - 15.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/array_floats.yml [NONE] - 18.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/array_integers.yml [NONE] - 12.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/array_mixed.yml [NONE] - 94.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/array_objects.yml [NONE] - 96.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/array_strings.yml [NONE] - 12.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/article.yml [NONE] - 19.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/blog_post.yml [NONE] - 313.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/blog_post_unauthored.yml [NONE] - 126.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/boolean_false.yml [NONE] - 6.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/boolean_true.yml [NONE] - 5.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/car.yml [NONE] - 16.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/car_without_type.yml [NONE] - 6.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/circular_reference.yml [NONE] - 140.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/currency_aware_price.yml [NONE] - 27.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/custom_accessor.yml [NONE] - 252.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/date_interval.yml [NONE] - 6.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/date_time.yml [NONE] - 27.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/float.yml [NONE] - 6.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/float_trailing_zero.yml [NONE] - 2.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/groups_all.yml [NONE] - 44.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/groups_default.yml [NONE] - 20.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/groups_foo.yml [NONE] - 24.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/groups_foobar.yml [NONE] - 33.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/hash_empty.yml [NONE] - 9.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/inline.yml [NONE] - 20.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/input.yml [NONE] - 65.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/integer.yml [NONE] - 2.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/lifecycle_callbacks.yml [NONE] - 16.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/log.yml [NONE] - 322.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/mixed_access_types.yml [NONE] - 44.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/null.yml [NONE] - 5.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/nullable.yml [NONE] - 19.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/object_when_null.yml [NONE] - 10.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/object_when_null_and_serialized.yml [NONE] - 23.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/order.yml [NONE] - 23.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/order_with_currency_aware_price.yml [NONE] - 41.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/orm_proxy.yml [NONE] - 40.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/price.yml [NONE] - 9.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/readonly.yml [NONE] - 35.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/simple_object.yml [NONE] - 34.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/simple_object_nullable.yml [NONE] - 54.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/string.yml [NONE] - 4.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/virtual_properties.yml [NONE] - 83.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/virtual_properties_all.yml [NONE] - 15.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/virtual_properties_high.yml [NONE] - 8.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Serializer/yml/virtual_properties_low.yml [NONE] - 7.00B
- vendor/jms/serializer/tests/JMS/Serializer/Tests/SerializerBuilderTest.php [NONE] - 4.73KB
- vendor/jms/serializer/tests/JMS/Serializer/Tests/Twig/SerializerExtensionTest.php [NONE] - 1.30KB
- vendor/jms/serializer/UPGRADING.md [NONE] - 815.00B
- vendor/phpcollection/phpcollection/composer.json [NONE] - 544.00B
- vendor/phpcollection/phpcollection/composer.lock [NONE] - 1.62KB
- vendor/phpcollection/phpcollection/doc/index.rst [NONE] - 2.95KB
- vendor/phpcollection/phpcollection/doc/LICENSE [NONE] - 15.76KB
- vendor/phpcollection/phpcollection/phpunit.xml.dist [NONE] - 681.00B
- vendor/phpcollection/phpcollection/README.md [NONE] - 114.00B
- vendor/phpcollection/phpcollection/tests/bootstrap.php [NONE] - 225.00B
- vendor/phpcollection/phpcollection/tests/PhpCollection/Tests/MapTest.php [NONE] - 5.15KB
- vendor/phpcollection/phpcollection/tests/PhpCollection/Tests/SequenceTest.php [NONE] - 7.24KB
- vendor/phpcollection/phpcollection/tests/PhpCollection/Tests/SortedSequenceTest.php [NONE] - 1.49KB
- vendor/phpoption/phpoption/composer.json [NONE] - 586.00B
- vendor/phpoption/phpoption/phpunit.xml.dist [NONE] - 678.00B
- vendor/phpoption/phpoption/README.md [NONE] - 5.59KB
- vendor/phpoption/phpoption/tests/bootstrap.php [NONE] - 225.00B
- vendor/phpoption/phpoption/tests/PhpOption/Tests/EnsureTest.php [NONE] - 1.84KB
- vendor/phpoption/phpoption/tests/PhpOption/Tests/LazyOptionTest.php [NONE] - 6.29KB
- vendor/phpoption/phpoption/tests/PhpOption/Tests/NoneTest.php [NONE] - 3.02KB
- vendor/phpoption/phpoption/tests/PhpOption/Tests/OptionTest.php [NONE] - 2.90KB
- vendor/phpoption/phpoption/tests/PhpOption/Tests/PerformanceTest.php [NONE] - 2.12KB
- vendor/phpoption/phpoption/tests/PhpOption/Tests/SomeTest.php [NONE] - 5.17KB
- vendor/psr/log/composer.json [NONE] - 561.00B
- vendor/psr/log/Psr/Log/Test/LoggerInterfaceTest.php [NONE] - 4.59KB
- vendor/psr/log/Psr/Log/Test/TestLogger.php [NONE] - 4.39KB
- vendor/psr/log/README.md [NONE] - 1.13KB
- vendor/symfony/console/CHANGELOG.md [NONE] - 2.25KB
- vendor/symfony/console/composer.json [NONE] - 1.13KB
- vendor/symfony/console/phpunit.xml.dist [NONE] - 1.18KB
- vendor/symfony/console/README.md [NONE] - 692.00B
- vendor/symfony/console/Tests/ApplicationTest.php [NONE] - 59.95KB
- vendor/symfony/console/Tests/Command/CommandTest.php [NONE] - 18.63KB
- vendor/symfony/console/Tests/Command/HelpCommandTest.php [NONE] - 3.56KB
- vendor/symfony/console/Tests/Command/ListCommandTest.php [NONE] - 4.03KB
- vendor/symfony/console/Tests/Descriptor/AbstractDescriptorTest.php [NONE] - 3.71KB
- vendor/symfony/console/Tests/Descriptor/JsonDescriptorTest.php [NONE] - 1.02KB
- vendor/symfony/console/Tests/Descriptor/MarkdownDescriptorTest.php [NONE] - 1.21KB
- vendor/symfony/console/Tests/Descriptor/ObjectsProvider.php [NONE] - 4.01KB
- vendor/symfony/console/Tests/Descriptor/TextDescriptorTest.php [NONE] - 1.20KB
- vendor/symfony/console/Tests/Descriptor/XmlDescriptorTest.php [NONE] - 566.00B
- vendor/symfony/console/Tests/Fixtures/application_1.json [NONE] - 7.43KB
- vendor/symfony/console/Tests/Fixtures/application_1.md [NONE] - 3.66KB
- vendor/symfony/console/Tests/Fixtures/application_1.txt [NONE] - 756.00B
- vendor/symfony/console/Tests/Fixtures/application_1.xml [NONE] - 4.73KB
- vendor/symfony/console/Tests/Fixtures/application_2.json [NONE] - 14.79KB
- vendor/symfony/console/Tests/Fixtures/application_2.md [NONE] - 7.04KB
- vendor/symfony/console/Tests/Fixtures/application_2.txt [NONE] - 1.07KB
- vendor/symfony/console/Tests/Fixtures/application_2.xml [NONE] - 8.82KB
- vendor/symfony/console/Tests/Fixtures/application_astext1.txt [NONE] - 874.00B
- vendor/symfony/console/Tests/Fixtures/application_astext2.txt [NONE] - 739.00B
- vendor/symfony/console/Tests/Fixtures/application_asxml1.txt [NONE] - 6.48KB
- vendor/symfony/console/Tests/Fixtures/application_asxml2.txt [NONE] - 1.74KB
- vendor/symfony/console/Tests/Fixtures/application_gethelp.txt [NONE] - 25.00B
- vendor/symfony/console/Tests/Fixtures/application_mbstring.md [NONE] - 5.57KB
- vendor/symfony/console/Tests/Fixtures/application_mbstring.txt [NONE] - 878.00B
- vendor/symfony/console/Tests/Fixtures/application_renderexception1.txt [NONE] - 270.00B
- vendor/symfony/console/Tests/Fixtures/application_renderexception2.txt [NONE] - 321.00B
- vendor/symfony/console/Tests/Fixtures/application_renderexception3.txt [NONE] - 554.00B
- vendor/symfony/console/Tests/Fixtures/application_renderexception3decorated.txt [NONE] - 756.00B
- vendor/symfony/console/Tests/Fixtures/application_renderexception4.txt [NONE] - 337.00B
- vendor/symfony/console/Tests/Fixtures/application_renderexception_doublewidth1.txt [NONE] - 99.00B
- vendor/symfony/console/Tests/Fixtures/application_renderexception_doublewidth1decorated.txt [NONE] - 173.00B
- vendor/symfony/console/Tests/Fixtures/application_renderexception_doublewidth2.txt [NONE] - 182.00B
- vendor/symfony/console/Tests/Fixtures/application_renderexception_escapeslines.txt [NONE] - 117.00B
- vendor/symfony/console/Tests/Fixtures/application_renderexception_linebreaks.txt [NONE] - 266.00B
- vendor/symfony/console/Tests/Fixtures/application_run1.txt [NONE] - 569.00B
- vendor/symfony/console/Tests/Fixtures/application_run2.txt [NONE] - 1.07KB
- vendor/symfony/console/Tests/Fixtures/application_run3.txt [NONE] - 710.00B
- vendor/symfony/console/Tests/Fixtures/application_run4.txt [NONE] - 13.00B
- vendor/symfony/console/Tests/Fixtures/BarBucCommand.php [NONE] - 177.00B
- vendor/symfony/console/Tests/Fixtures/command_1.json [NONE] - 274.00B
- vendor/symfony/console/Tests/Fixtures/command_1.md [NONE] - 156.00B
- vendor/symfony/console/Tests/Fixtures/command_1.txt [NONE] - 109.00B
- vendor/symfony/console/Tests/Fixtures/command_1.xml [NONE] - 335.00B
- vendor/symfony/console/Tests/Fixtures/command_2.json [NONE] - 939.00B
- vendor/symfony/console/Tests/Fixtures/command_2.md [NONE] - 580.00B
- vendor/symfony/console/Tests/Fixtures/command_2.txt [NONE] - 348.00B
- vendor/symfony/console/Tests/Fixtures/command_2.xml [NONE] - 778.00B
- vendor/symfony/console/Tests/Fixtures/command_astext.txt [NONE] - 720.00B
- vendor/symfony/console/Tests/Fixtures/command_asxml.txt [NONE] - 1.71KB
- vendor/symfony/console/Tests/Fixtures/command_mbstring.md [NONE] - 589.00B
- vendor/symfony/console/Tests/Fixtures/command_mbstring.txt [NONE] - 350.00B
- vendor/symfony/console/Tests/Fixtures/definition_astext.txt [NONE] - 804.00B
- vendor/symfony/console/Tests/Fixtures/definition_asxml.txt [NONE] - 1.23KB
- vendor/symfony/console/Tests/Fixtures/DescriptorApplication1.php [NONE] - 388.00B
- vendor/symfony/console/Tests/Fixtures/DescriptorApplication2.php [NONE] - 589.00B
- vendor/symfony/console/Tests/Fixtures/DescriptorApplicationMbString.php [NONE] - 550.00B
- vendor/symfony/console/Tests/Fixtures/DescriptorCommand1.php [NONE] - 646.00B
- vendor/symfony/console/Tests/Fixtures/DescriptorCommand2.php [NONE] - 932.00B
- vendor/symfony/console/Tests/Fixtures/DescriptorCommandMbString.php [NONE] - 951.00B
- vendor/symfony/console/Tests/Fixtures/DummyOutput.php [NONE] - 802.00B
- vendor/symfony/console/Tests/Fixtures/Foo1Command.php [NONE] - 597.00B
- vendor/symfony/console/Tests/Fixtures/Foo2Command.php [NONE] - 493.00B
- vendor/symfony/console/Tests/Fixtures/Foo3Command.php [NONE] - 833.00B
- vendor/symfony/console/Tests/Fixtures/Foo4Command.php [NONE] - 180.00B
- vendor/symfony/console/Tests/Fixtures/Foo5Command.php [NONE] - 139.00B
- vendor/symfony/console/Tests/Fixtures/Foo6Command.php [NONE] - 212.00B
- vendor/symfony/console/Tests/Fixtures/FoobarCommand.php [NONE] - 559.00B
- vendor/symfony/console/Tests/Fixtures/FooCommand.php [NONE] - 768.00B
- vendor/symfony/console/Tests/Fixtures/FooOptCommand.php [NONE] - 972.00B
- vendor/symfony/console/Tests/Fixtures/FooSubnamespaced1Command.php [NONE] - 617.00B
- vendor/symfony/console/Tests/Fixtures/FooSubnamespaced2Command.php [NONE] - 615.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_1.json [NONE] - 124.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_1.md [NONE] - 116.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_1.txt [NONE] - 29.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_1.xml [NONE] - 156.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_2.json [NONE] - 142.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_2.md [NONE] - 134.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_2.txt [NONE] - 51.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_2.xml [NONE] - 176.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_3.json [NONE] - 156.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_3.md [NONE] - 140.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_3.txt [NONE] - 97.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_3.xml [NONE] - 226.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_4.json [NONE] - 154.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_4.md [NONE] - 142.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_4.txt [NONE] - 78.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_4.xml [NONE] - 186.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_with_default_inf_value.json [NONE] - 146.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_with_default_inf_value.md [NONE] - 128.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_with_default_inf_value.txt [NONE] - 85.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_with_default_inf_value.xml [NONE] - 216.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_with_style.json [NONE] - 160.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_with_style.md [NONE] - 144.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_with_style.txt [NONE] - 103.00B
- vendor/symfony/console/Tests/Fixtures/input_argument_with_style.xml [NONE] - 242.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_1.json [NONE] - 43.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_1.md [NONE] - 0.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_1.txt [NONE] - 0.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_1.xml [NONE] - 94.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_2.json [NONE] - 245.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_2.md [NONE] - 132.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_2.txt [NONE] - 59.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_2.xml [NONE] - 241.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_3.json [NONE] - 319.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_3.md [NONE] - 175.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_3.txt [NONE] - 61.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_3.xml [NONE] - 257.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_4.json [NONE] - 521.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_4.md [NONE] - 308.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_4.txt [NONE] - 127.00B
- vendor/symfony/console/Tests/Fixtures/input_definition_4.xml [NONE] - 404.00B
- vendor/symfony/console/Tests/Fixtures/input_option_1.json [NONE] - 184.00B
- vendor/symfony/console/Tests/Fixtures/input_option_1.md [NONE] - 161.00B
- vendor/symfony/console/Tests/Fixtures/input_option_1.txt [NONE] - 33.00B
- vendor/symfony/console/Tests/Fixtures/input_option_1.xml [NONE] - 178.00B
- vendor/symfony/console/Tests/Fixtures/input_option_2.json [NONE] - 211.00B
- vendor/symfony/console/Tests/Fixtures/input_option_2.md [NONE] - 184.00B
- vendor/symfony/console/Tests/Fixtures/input_option_2.txt [NONE] - 113.00B
- vendor/symfony/console/Tests/Fixtures/input_option_2.xml [NONE] - 260.00B
- vendor/symfony/console/Tests/Fixtures/input_option_3.json [NONE] - 199.00B
- vendor/symfony/console/Tests/Fixtures/input_option_3.md [NONE] - 174.00B
- vendor/symfony/console/Tests/Fixtures/input_option_3.txt [NONE] - 65.00B
- vendor/symfony/console/Tests/Fixtures/input_option_3.xml [NONE] - 210.00B
- vendor/symfony/console/Tests/Fixtures/input_option_4.json [NONE] - 197.00B
- vendor/symfony/console/Tests/Fixtures/input_option_4.md [NONE] - 178.00B
- vendor/symfony/console/Tests/Fixtures/input_option_4.txt [NONE] - 112.00B
- vendor/symfony/console/Tests/Fixtures/input_option_4.xml [NONE] - 210.00B
- vendor/symfony/console/Tests/Fixtures/input_option_5.json [NONE] - 209.00B
- vendor/symfony/console/Tests/Fixtures/input_option_5.md [NONE] - 186.00B
- vendor/symfony/console/Tests/Fixtures/input_option_5.txt [NONE] - 108.00B
- vendor/symfony/console/Tests/Fixtures/input_option_5.xml [NONE] - 220.00B
- vendor/symfony/console/Tests/Fixtures/input_option_6.json [NONE] - 214.00B
- vendor/symfony/console/Tests/Fixtures/input_option_6.md [NONE] - 189.00B
- vendor/symfony/console/Tests/Fixtures/input_option_6.txt [NONE] - 79.00B
- vendor/symfony/console/Tests/Fixtures/input_option_6.xml [NONE] - 240.00B
- vendor/symfony/console/Tests/Fixtures/input_option_with_default_inf_value.json [NONE] - 201.00B
- vendor/symfony/console/Tests/Fixtures/input_option_with_default_inf_value.md [NONE] - 172.00B
- vendor/symfony/console/Tests/Fixtures/input_option_with_default_inf_value.txt [NONE] - 101.00B
- vendor/symfony/console/Tests/Fixtures/input_option_with_default_inf_value.xml [NONE] - 250.00B
- vendor/symfony/console/Tests/Fixtures/input_option_with_style.json [NONE] - 214.00B
- vendor/symfony/console/Tests/Fixtures/input_option_with_style.md [NONE] - 189.00B
- vendor/symfony/console/Tests/Fixtures/input_option_with_style.txt [NONE] - 117.00B
- vendor/symfony/console/Tests/Fixtures/input_option_with_style.xml [NONE] - 276.00B
- vendor/symfony/console/Tests/Fixtures/input_option_with_style_array.json [NONE] - 266.00B
- vendor/symfony/console/Tests/Fixtures/input_option_with_style_array.md [NONE] - 241.00B
- vendor/symfony/console/Tests/Fixtures/input_option_with_style_array.txt [NONE] - 194.00B
- vendor/symfony/console/Tests/Fixtures/input_option_with_style_array.xml [NONE] - 337.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_0.php [NONE] - 446.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_1.php [NONE] - 496.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_10.php [NONE] - 980.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_11.php [NONE] - 653.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_12.php [NONE] - 929.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_13.php [NONE] - 970.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_14.php [NONE] - 939.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_15.php [NONE] - 899.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_16.php [NONE] - 936.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_17.php [NONE] - 524.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_2.php [NONE] - 609.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_3.php [NONE] - 450.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_4.php [NONE] - 1.20KB
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_5.php [NONE] - 1.13KB
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_6.php [NONE] - 594.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_7.php [NONE] - 712.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_8.php [NONE] - 880.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/command/command_9.php [NONE] - 532.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_0.txt [NONE] - 123.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_1.txt [NONE] - 149.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_10.txt [NONE] - 607.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_11.txt [NONE] - 246.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_12.txt [NONE] - 486.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_13.txt [NONE] - 727.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_14.txt [NONE] - 486.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_15.txt [NONE] - 607.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_16.txt [NONE] - 824.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_17.txt [NONE] - 87.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_2.txt [NONE] - 733.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_3.txt [NONE] - 53.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_4.txt [NONE] - 324.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_5.txt [NONE] - 655.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_6.txt [NONE] - 185.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_7.txt [NONE] - 78.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_8.txt [NONE] - 457.00B
- vendor/symfony/console/Tests/Fixtures/Style/SymfonyStyle/output/output_9.txt [NONE] - 365.00B
- vendor/symfony/console/Tests/Fixtures/TestCommand.php [NONE] - 698.00B
- vendor/symfony/console/Tests/Fixtures/TestTiti.php [NONE] - 485.00B
- vendor/symfony/console/Tests/Fixtures/TestToto.php [NONE] - 525.00B
- vendor/symfony/console/Tests/Formatter/OutputFormatterStyleStackTest.php [NONE] - 2.13KB
- vendor/symfony/console/Tests/Formatter/OutputFormatterStyleTest.php [NONE] - 4.00KB
- vendor/symfony/console/Tests/Formatter/OutputFormatterTest.php [NONE] - 8.73KB
- vendor/symfony/console/Tests/Helper/FormatterHelperTest.php [NONE] - 3.04KB
- vendor/symfony/console/Tests/Helper/HelperSetTest.php [NONE] - 5.43KB
- vendor/symfony/console/Tests/Helper/HelperTest.php [NONE] - 1.46KB
- vendor/symfony/console/Tests/Helper/LegacyDialogHelperTest.php [NONE] - 11.27KB
- vendor/symfony/console/Tests/Helper/LegacyProgressHelperTest.php [NONE] - 7.72KB
- vendor/symfony/console/Tests/Helper/LegacyTableHelperTest.php [NONE] - 10.75KB
- vendor/symfony/console/Tests/Helper/ProcessHelperTest.php [NONE] - 4.80KB
- vendor/symfony/console/Tests/Helper/ProgressBarTest.php [NONE] - 22.14KB
- vendor/symfony/console/Tests/Helper/ProgressIndicatorTest.php [NONE] - 5.24KB
- vendor/symfony/console/Tests/Helper/QuestionHelperTest.php [NONE] - 28.40KB
- vendor/symfony/console/Tests/Helper/SymfonyQuestionHelperTest.php [NONE] - 7.82KB
- vendor/symfony/console/Tests/Helper/TableStyleTest.php [NONE] - 739.00B
- vendor/symfony/console/Tests/Helper/TableTest.php [NONE] - 27.90KB
- vendor/symfony/console/Tests/Input/ArgvInputTest.php [NONE] - 21.30KB
- vendor/symfony/console/Tests/Input/ArrayInputTest.php [NONE] - 5.84KB
- vendor/symfony/console/Tests/Input/InputArgumentTest.php [NONE] - 4.43KB
- vendor/symfony/console/Tests/Input/InputDefinitionTest.php [NONE] - 18.47KB
- vendor/symfony/console/Tests/Input/InputOptionTest.php [NONE] - 9.24KB
- vendor/symfony/console/Tests/Input/InputTest.php [NONE] - 5.92KB
- vendor/symfony/console/Tests/Input/StringInputTest.php [NONE] - 4.87KB
- vendor/symfony/console/Tests/Logger/ConsoleLoggerTest.php [NONE] - 5.51KB
- vendor/symfony/console/Tests/Output/ConsoleOutputTest.php [NONE] - 1.39KB
- vendor/symfony/console/Tests/Output/NullOutputTest.php [NONE] - 2.52KB
- vendor/symfony/console/Tests/Output/OutputTest.php [NONE] - 6.34KB
- vendor/symfony/console/Tests/Output/StreamOutputTest.php [NONE] - 1.77KB
- vendor/symfony/console/Tests/Style/SymfonyStyleTest.php [NONE] - 2.07KB
- vendor/symfony/console/Tests/Tester/ApplicationTesterTest.php [NONE] - 2.36KB
- vendor/symfony/console/Tests/Tester/CommandTesterTest.php [NONE] - 2.83KB
- vendor/symfony/contracts/CHANGELOG.md [NONE] - 636.00B
- vendor/symfony/contracts/composer.json [NONE] - 1.24KB
- vendor/symfony/contracts/phpunit.xml.dist [NONE] - 827.00B
- vendor/symfony/contracts/README.md [NONE] - 3.27KB
- vendor/symfony/contracts/Tests/Cache/CacheTraitTest.php [NONE] - 3.93KB
- vendor/symfony/contracts/Tests/Service/ServiceLocatorTest.php [NONE] - 2.79KB
- vendor/symfony/contracts/Tests/Service/ServiceSubscriberTraitTest.php [NONE] - 1.57KB
- vendor/symfony/contracts/Tests/Translation/TranslatorTest.php [NONE] - 14.81KB
- vendor/symfony/debug/CHANGELOG.md [NONE] - 1.02KB
- vendor/symfony/debug/composer.json [NONE] - 1,000.00B
- vendor/symfony/debug/phpunit.xml.dist [NONE] - 930.00B
- vendor/symfony/debug/README.md [NONE] - 482.00B
- vendor/symfony/debug/Resources/ext/README.md [NONE] - 2.92KB
- vendor/symfony/debug/Resources/ext/tests/001.phpt [NONE] - 2.58KB
- vendor/symfony/debug/Resources/ext/tests/002.phpt [NONE] - 912.00B
- vendor/symfony/debug/Resources/ext/tests/002_1.phpt [NONE] - 643.00B
- vendor/symfony/debug/Resources/ext/tests/003.phpt [NONE] - 2.03KB
- vendor/symfony/debug/Tests/DebugClassLoaderTest.php [NONE] - 10.69KB
- vendor/symfony/debug/Tests/ErrorHandlerTest.php [NONE] - 17.55KB
- vendor/symfony/debug/Tests/Exception/FlattenExceptionTest.php [NONE] - 10.54KB
- vendor/symfony/debug/Tests/ExceptionHandlerTest.php [NONE] - 3.94KB
- vendor/symfony/debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php [NONE] - 7.34KB
- vendor/symfony/debug/Tests/FatalErrorHandler/UndefinedFunctionFatalErrorHandlerTest.php [NONE] - 3.09KB
- vendor/symfony/debug/Tests/FatalErrorHandler/UndefinedMethodFatalErrorHandlerTest.php [NONE] - 2.51KB
- vendor/symfony/debug/Tests/Fixtures/casemismatch.php [NONE] - 81.00B
- vendor/symfony/debug/Tests/Fixtures/ClassAlias.php [NONE] - 126.00B
- vendor/symfony/debug/Tests/Fixtures/DeprecatedClass.php [NONE] - 172.00B
- vendor/symfony/debug/Tests/Fixtures/DeprecatedInterface.php [NONE] - 180.00B
- vendor/symfony/debug/Tests/Fixtures/NonDeprecatedInterface.php [NONE] - 123.00B
- vendor/symfony/debug/Tests/Fixtures/notPsr0Bis.php [NONE] - 79.00B
- vendor/symfony/debug/Tests/Fixtures/PEARClass.php [NONE] - 66.00B
- vendor/symfony/debug/Tests/Fixtures/psr4/Psr4CaseMismatch.php [NONE] - 85.00B
- vendor/symfony/debug/Tests/Fixtures/reallyNotPsr0.php [NONE] - 76.00B
- vendor/symfony/debug/Tests/Fixtures/ToStringThrower.php [NONE] - 541.00B
- vendor/symfony/debug/Tests/Fixtures2/RequiredTwice.php [NONE] - 83.00B
- vendor/symfony/debug/Tests/HeaderMock.php [NONE] - 673.00B
- vendor/symfony/debug/Tests/MockExceptionHandler.php [NONE] - 476.00B
- vendor/symfony/event-dispatcher/CHANGELOG.md [NONE] - 1.63KB
- vendor/symfony/event-dispatcher/composer.json [NONE] - 1.20KB
- vendor/symfony/event-dispatcher/phpunit.xml.dist [NONE] - 893.00B
- vendor/symfony/event-dispatcher/README.md [NONE] - 610.00B
- vendor/symfony/event-dispatcher/Tests/AbstractEventDispatcherTest.php [NONE] - 15.58KB
- vendor/symfony/event-dispatcher/Tests/Debug/TraceableEventDispatcherTest.php [NONE] - 11.82KB
- vendor/symfony/event-dispatcher/Tests/Debug/WrappedListenerTest.php [NONE] - 2.03KB
- vendor/symfony/event-dispatcher/Tests/DependencyInjection/RegisterListenersPassTest.php [NONE] - 6.97KB
- vendor/symfony/event-dispatcher/Tests/EventDispatcherTest.php [NONE] - 509.00B
- vendor/symfony/event-dispatcher/Tests/EventTest.php [NONE] - 1.25KB
- vendor/symfony/event-dispatcher/Tests/GenericEventTest.php [NONE] - 3.46KB
- vendor/symfony/event-dispatcher/Tests/ImmutableEventDispatcherTest.php [NONE] - 2.91KB
- vendor/symfony/expression-language/CHANGELOG.md [NONE] - 139.00B
- vendor/symfony/expression-language/composer.json [NONE] - 792.00B
- vendor/symfony/expression-language/phpunit.xml.dist [NONE] - 845.00B
- vendor/symfony/expression-language/README.md [NONE] - 651.00B
- vendor/symfony/expression-language/Tests/ExpressionLanguageTest.php [NONE] - 7.82KB
- vendor/symfony/expression-language/Tests/ExpressionTest.php [NONE] - 723.00B
- vendor/symfony/expression-language/Tests/Fixtures/TestProvider.php [NONE] - 787.00B
- vendor/symfony/expression-language/Tests/LexerTest.php [NONE] - 3.69KB
- vendor/symfony/expression-language/Tests/Node/AbstractNodeTest.php [NONE] - 1.03KB
- vendor/symfony/expression-language/Tests/Node/ArgumentsNodeTest.php [NONE] - 636.00B
- vendor/symfony/expression-language/Tests/Node/ArrayNodeTest.php [NONE] - 1.45KB
- vendor/symfony/expression-language/Tests/Node/BinaryNodeTest.php [NONE] - 6.57KB
- vendor/symfony/expression-language/Tests/Node/ConditionalNodeTest.php [NONE] - 1.10KB
- vendor/symfony/expression-language/Tests/Node/ConstantNodeTest.php [NONE] - 1.31KB
- vendor/symfony/expression-language/Tests/Node/FunctionNodeTest.php [NONE] - 1.23KB
- vendor/symfony/expression-language/Tests/Node/GetAttrNodeTest.php [NONE] - 2.68KB
- vendor/symfony/expression-language/Tests/Node/NameNodeTest.php [NONE] - 687.00B
- vendor/symfony/expression-language/Tests/Node/NodeTest.php [NONE] - 976.00B
- vendor/symfony/expression-language/Tests/Node/UnaryNodeTest.php [NONE] - 1.16KB
- vendor/symfony/expression-language/Tests/ParsedExpressionTest.php [NONE] - 814.00B
- vendor/symfony/expression-language/Tests/ParserTest.php [NONE] - 6.30KB
- vendor/symfony/polyfill-mbstring/composer.json [NONE] - 880.00B
- vendor/symfony/polyfill-mbstring/README.md [NONE] - 371.00B
+ .box/.requirements.php [NONE] - 4.17KB
+ .box/bin/check-requirements.php [NONE] - 551.00B
+ .box/composer.json [NONE] - 591.00B
+ .box/composer.lock [NONE] - 52.84KB
+ .box/src/Checker.php [NONE] - 4.81KB
+ .box/src/IO.php [NONE] - 3.91KB
+ .box/src/IsExtensionFulfilled.php [NONE] - 434.00B
+ .box/src/IsFulfilled.php [NONE] - 127.00B
+ .box/src/IsPhpVersionFulfilled.php [NONE] - 615.00B
+ .box/src/Printer.php [NONE] - 3.29KB
+ .box/src/Requirement.php [NONE] - 902.00B
+ .box/src/RequirementCollection.php [NONE] - 1.28KB
+ .box/src/Terminal.php [NONE] - 3.01KB
+ .box/vendor/autoload.php [NONE] - 438.00B
+ .box/vendor/composer/autoload_classmap.php [NONE] - 2.17KB
+ .box/vendor/composer/autoload_namespaces.php [NONE] - 149.00B
+ .box/vendor/composer/autoload_psr4.php [NONE] - 328.00B
+ .box/vendor/composer/autoload_real.php [NONE] - 1.42KB
+ .box/vendor/composer/autoload_static.php [NONE] - 3.44KB
+ .box/vendor/composer/ClassLoader.php [NONE] - 13.14KB
+ .box/vendor/composer/installed.json [NONE] - 31.13KB
+ .box/vendor/composer/LICENSE [NONE] - 1.04KB
+ .box/vendor/composer/semver/LICENSE [NONE] - 1.03KB
+ .box/vendor/composer/semver/src/Comparator.php [NONE] - 1.22KB
+ .box/vendor/composer/semver/src/Constraint/AbstractConstraint.php [NONE] - 934.00B
+ .box/vendor/composer/semver/src/Constraint/Constraint.php [NONE] - 3.79KB
+ .box/vendor/composer/semver/src/Constraint/ConstraintInterface.php [NONE] - 287.00B
+ .box/vendor/composer/semver/src/Constraint/EmptyConstraint.php [NONE] - 695.00B
+ .box/vendor/composer/semver/src/Constraint/MultiConstraint.php [NONE] - 1.77KB
+ .box/vendor/composer/semver/src/Semver.php [NONE] - 2.30KB
+ .box/vendor/composer/semver/src/VersionParser.php [NONE] - 14.85KB

 [ERROR] 657 file(s) difference                                                                                         
                                                                                     
```
</details>

Note that I did not attempt to apply PHP-Scoper either, which could be done with Box3. I however would advise doing it in a dedicated PR in which you can also introduce an e2e test to ensure the scoped PHAR works as expected.