### PR TITLE
Athib/fix deprecated warning

### DIFF
--- a/Sdk/Model/Violations.php
+++ b/Sdk/Model/Violations.php
@@ -23,7 +23,7 @@ class Violations implements \Countable, \IteratorAggregate
     private $violations = [];
 
     public function count(): int
-    {/
+    {
         return \count($this->violations);
     }
 

--- a/Sdk/Model/Violations.php
+++ b/Sdk/Model/Violations.php
@@ -22,12 +22,12 @@ class Violations implements \Countable, \IteratorAggregate
      */
     private $violations = [];
 
-    public function count()
-    {
+    public function count(): int
+    {/
         return \count($this->violations);
     }
 
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->violations);
     }


### PR DESCRIPTION
Adding return types on `SensioLabs\Insight\Sdk\Model\Violations` to fix the deprecated notices on analysis

> Deprecated: Return type of SensioLabs\Insight\Sdk\Model\Violations::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/bin/insight/Sdk/Model/Violations.php on line 25
Deprecated: Return type of SensioLabs\Insight\Sdk\Model\Violations::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in phar:///usr/bin/insight/Sdk/Model/Violations.php on line 30