### PR TITLE
Fix PHP8 nullable argument deprecation

### DIFF
--- a/Sdk/Api.php
+++ b/Sdk/Api.php
@@ -39,7 +39,7 @@ class Api
     private $parser;
     private $logger;
 
-    public function __construct(array $options = [], HttpClientInterface $httpClient = null, Parser $parser = null, LoggerInterface $logger = null)
+    public function __construct(array $options = [], ?HttpClientInterface $httpClient = null, ?Parser $parser = null, ?LoggerInterface $logger = null)
     {
         $this->httpClient = $httpClient ?: HttpClient::create();
         $this->parser = $parser ?: new Parser();


### PR DESCRIPTION
We have deprecations of work project due to Api.php constructor

```
eprecated: SensioLabs\Insight\Sdk\Api::__construct(): Implicitly marking parameter $httpClient as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/bin/insight/Sdk/Api.php on line 42
Deprecated: SensioLabs\Insight\Sdk\Api::__construct(): Implicitly marking parameter $parser as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/bin/insight/Sdk/Api.php on line 42
Deprecated: SensioLabs\Insight\Sdk\Api::__construct(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead in phar:///usr/bin/insight/Sdk/Api.php on line 42
```