### PR TITLE
Make insight.phar publicly accessible after release

### DIFF
--- a/.github/workflows/only-main.yaml
+++ b/.github/workflows/only-main.yaml
@@ -46,4 +46,4 @@ jobs:
 
             - name: Release
               run: |
-                  aws s3 cp build/insight.phar s3://get.insight.symfony.com/insight.phar
+                  aws s3 cp build/insight.phar s3://get.insight.symfony.com/insight.phar --acl public-read


### PR DESCRIPTION
Context: https://github.com/symfonycorp/insight/issues/112
Reference: https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html